### PR TITLE
[fix] colcon build時に発生していたwarningへの対処

### DIFF
--- a/shigure_core/setup.cfg
+++ b/shigure_core/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/shigure_core
+script_dir=$base/lib/shigure_core
 [install]
-install-scripts=$base/lib/shigure_core
+install_scripts=$base/lib/shigure_core


### PR DESCRIPTION
[[ROS2] UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead](https://answers.ros.org/question/386341/ros2-userwarning-usage-of-dash-separated-install-scripts-will-not-be-supported-in-future-versions-please-use-the-underscore-name-install_scripts/)

上記と同様のエラーへの対処
以下, warning発生時の様子

![shigure_warning_2022-08-31](https://user-images.githubusercontent.com/64585615/187611267-e94d9248-7e2c-4c52-8fc2-b3458be533fd.png)


