### PR TITLE
[fix] debug mode True時にobject_tracking, people_trackingが動作しない問題の修正

### DIFF
--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -53,7 +53,12 @@ class ObjectTrackingNode(ImagePreviewNode):
                 [depth_subscriber, object_detection_subscriber, depth_camera_info_subscriber], 30000)
             self.time_synchronizer.registerCallback(self.callback)
         else:
-            color_subscriber = message_filters.Subscriber(self, CompressedImage, '/rs/color/compressed')
+            color_subscriber = message_filters.Subscriber(
+                self, 
+                CompressedImage, 
+                '/rs/color/compressed',
+                qos_profile=shigure_qos
+            )
             self.time_synchronizer = message_filters.TimeSynchronizer(
                 [depth_subscriber, object_detection_subscriber, depth_camera_info_subscriber, color_subscriber], 400000)
             self.time_synchronizer.registerCallback(self.callback_debug)

--- a/shigure_core/shigure_core/nodes/node_people_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_people_tracking.py
@@ -54,7 +54,12 @@ class PeopleTrackingNode(ImagePreviewNode):
                 [depth_subscriber, key_points_subscriber, depth_camera_info_subscriber], 30000)
             self.time_synchronizer.registerCallback(self.callback)
         else:
-            color_subscriber = message_filters.Subscriber(self, CompressedImage, '/rs/color/compressed')
+            color_subscriber = message_filters.Subscriber(
+                self, 
+                CompressedImage, 
+                '/rs/color/compressed', 
+                qos_profile=shigure_qos
+            )
             self.time_synchronizer = message_filters.TimeSynchronizer(
                 [depth_subscriber, key_points_subscriber, depth_camera_info_subscriber, color_subscriber], 400000)
             self.time_synchronizer.registerCallback(self.callback_debug)


### PR DESCRIPTION
原因 :
realsense cameraノードにおけるpublisherのQoS変更に伴い、debug_mode=true時のみ受け取るtopicに対してQoS設定を適用できておらず DefalutのReliableになってしまっており、callback関数が呼ばれていなかったため