### PR TITLE
[fix] カメラ変更後にobject_cubeでz座標を正しく取得できていなかったため修正

### DIFF
--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -107,8 +107,10 @@ class ObjectTrackingNode(ImagePreviewNode):
             right = min(int(bounding_box.x + bounding_box.width), width - 1)
             bottom = min(int(bounding_box.y + bounding_box.height), height - 1)
 
-            depth_min = depth_img[top:bottom, left:right].min()
-            depth_max = depth_img[top:bottom, left:right].max()
+            masked_depth_img = np.ma.masked_equal(depth_img[top:bottom, left:right], 0.0, copy=False)
+
+            depth_min = masked_depth_img.min()
+            depth_max = masked_depth_img.max()
 
             s1 = np.asarray([[bounding_box.x, bounding_box.y, 1]]).T
             s2 = np.asarray([[bounding_box.x + bounding_box.width,
@@ -118,8 +120,8 @@ class ObjectTrackingNode(ImagePreviewNode):
             m2 = (depth_img[bottom, right] * np.matmul(k_inv, s2)).T
 
             collider = Cube()
-            collider.x, collider.y = m1[0, 0], m1[0, 1]
-            collider.width, collider.height = m2[0, 0] - m1[0, 0], m2[0, 1] - m1[0, 1]
+            collider.x, collider.y = float(m1[0, 0]), float(m1[0, 1])
+            collider.width, collider.height = float(m2[0, 0] - m1[0, 0]), float(m2[0, 1] - m1[0, 1])
             collider.z = float(depth_min)
             collider.depth = float(depth_max - depth_min)
             tracked_object.collider = collider


### PR DESCRIPTION
realsenseD435 → realsenseD455の変更に伴い、これまで正しく取得できていた持ち込み・持ち去り物体のz座標が0になってしまう状況が発生したため、depth画像をマスクする処理を追加