### PR TITLE
fix: is_debug_modeをDynamic Reconfigure可能に修正

### DIFF
--- a/shigure_core/shigure_core/nodes/node_contact_detection.py
+++ b/shigure_core/shigure_core/nodes/node_contact_detection.py
@@ -250,6 +250,7 @@ class ContactDetectionNode(ImagePreviewNode):
 
             cv2.waitKey(1)
         else:
+            cv2.destroyAllWindows()
             print(f'[{datetime.datetime.now()}] fps : {self.fps}', end='\r')
 
     @staticmethod

--- a/shigure_core/shigure_core/nodes/node_image_preview.py
+++ b/shigure_core/shigure_core/nodes/node_image_preview.py
@@ -1,6 +1,9 @@
+from typing import List
+
 import cv2
 import numpy as np
-from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType, SetParametersResult
+from rcl_interfaces.msg import Parameter
 from rclpy.node import Node
 from cv_bridge import CvBridge
 
@@ -28,8 +31,26 @@ class ImagePreviewNode(Node):
         self.tm = cv2.TickMeter()
         self.tm.start()
 
+        self.add_on_set_parameters_callback(self._on_set_parameters)
+
         # show info
         self.get_logger().info('IsDebugMode : ' + str(self.is_debug_mode))
+
+    def _on_set_parameters(self, params: List[Parameter]) -> SetParametersResult:
+        """
+        パラメータ変更時に呼び出されるコールバックです.
+        ros2 param set コマンドなどで動的にパラメータを変更した際に反映されます.
+
+        :param params: 変更されたパラメータのリスト
+        :return: パラメータ変更の成否
+        """
+        for param in params:
+            if param.name == 'is_debug_mode':
+                self.is_debug_mode = param.value
+                self.get_logger().info('IsDebugMode : ' + str(self.is_debug_mode))
+                if not self.is_debug_mode:
+                    cv2.destroyAllWindows()
+        return SetParametersResult(successful=True)
 
     def frame_count_up(self):
         """

--- a/shigure_core/shigure_core/nodes/node_image_preview.py
+++ b/shigure_core/shigure_core/nodes/node_image_preview.py
@@ -48,8 +48,6 @@ class ImagePreviewNode(Node):
             if param.name == 'is_debug_mode':
                 self.is_debug_mode = param.value
                 self.get_logger().info('IsDebugMode : ' + str(self.is_debug_mode))
-                if not self.is_debug_mode:
-                    cv2.destroyAllWindows()
         return SetParametersResult(successful=True)
 
     def frame_count_up(self):

--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -134,9 +134,13 @@ class ObjectTrackingNode(ImagePreviewNode):
 
     def callback_debug(self, depth_src: CompressedImage, detected_object_list: DetectedObjectList,
                        camera_info: CameraInfo, color_src: CompressedImage):
-        color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_src)
-
         self.callback(depth_src, detected_object_list, camera_info)
+
+        if not self.is_debug_mode:
+            cv2.destroyAllWindows()
+            return
+
+        color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_src)
 
         height, width = color_img.shape[:2]
         for object_id, item in self._tracking_info.object_dict.items():

--- a/shigure_core/shigure_core/nodes/node_people_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_people_tracking.py
@@ -101,6 +101,11 @@ class PeopleTrackingNode(ImagePreviewNode):
     def callback_debug(self, depth_src: CompressedImage, key_points_list: OpenPosePoseKeyPointsList,
                        camera_info: CameraInfo, color_src: CompressedImage):
         published_msg: ShigurePoseKeyPointsList = self.callback(depth_src, key_points_list, camera_info)
+
+        if not self.is_debug_mode:
+            cv2.destroyAllWindows()
+            return
+
         color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_src)
         height, width = color_img.shape[:2]
 

--- a/shigure_core/shigure_core/nodes/node_yolox_object_detection.py
+++ b/shigure_core/shigure_core/nodes/node_yolox_object_detection.py
@@ -273,8 +273,8 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 			cv2.namedWindow('yolox_object_detection', cv2.WINDOW_NORMAL)
 			cv2.imshow("yolox_object_detection", tile_img)
 			cv2.waitKey(1)
-		#else:
-			#print(f'[{datetime.datetime.now()}] fps : {self.fps}', end='\r')
+		else:
+			cv2.destroyAllWindows()
 			
 			
 			


### PR DESCRIPTION
閾値調整など効率化のため，shigure_coreの主要ノードとそのロジックに存在するパラメータを随時Dynamic Reconfigureに対応させていきます．
本プルリクエストでは以下の4ノードに対して，is_debug_modeフラグを実行中に変更可能にし，false時にはcv2の描画を停止するようにしました．
1. contact_detection_node
2. object_tracking_node
3. people_tracking_node
4. yolox_object_detection_node