### PR TITLE
YOLO11subscribe化＆深度最大/最小値取得ロジック変更&YOLOクラス名テーブル修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ shigure_core/resource/db/Dockerfile.sample
 shigure_core/resource/db/Dockerfile_migration
 shigure_core/shigure_core/nodes/past_record_script/
 shigure_core/shigure_core/nodes/yolox_object_detection/logic.py_sample
-
+build/
+install/
+log/

--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -206,24 +206,26 @@ class ObjectTrackingNode(ImagePreviewNode):
                 valid = (eroded_mask > 0) & (depth_roi > 0)
                 if valid.any():
                     vals = depth_roi[valid]
-                    depth_min = float(vals.min())
-                    depth_max = float(vals.max())
                     p5, p50, p95 = np.percentile(vals, [5, 50, 95])
-                    depth_stats_log = f' p5={p5:.0f} median={p50:.0f} p95={p95:.0f}'
+                    depth_min = float(p5)
+                    depth_max = float(p95)
+                    depth_stats_log = f' p5={p5:.0f} median={p50:.0f} p95={p95:.0f} raw_min={vals.min():.0f} raw_max={vals.max():.0f}'
                     path_taken = f'eroded({valid.sum()}px)'
                 else:
                     valid_fallback = (seg_mask > 0) & (depth_roi > 0)
                     if valid_fallback.any():
-                        depth_min = float(depth_roi[valid_fallback].min())
-                        depth_max = float(depth_roi[valid_fallback].max())
+                        vals_fb = depth_roi[valid_fallback]
+                        depth_min = float(np.percentile(vals_fb, 5))
+                        depth_max = float(np.percentile(vals_fb, 95))
                         path_taken = f'mask_only({valid_fallback.sum()}px)'
 
             if depth_min is None or depth_max is None:
                 masked_depth_img = np.ma.masked_equal(depth_roi, 0.0, copy=False)
                 if masked_depth_img.count() == 0:
                     continue
-                depth_min = float(masked_depth_img.min())
-                depth_max = float(masked_depth_img.max())
+                vals_bb = masked_depth_img.compressed()
+                depth_min = float(np.percentile(vals_bb, 5))
+                depth_max = float(np.percentile(vals_bb, 95))
                 path_taken = f'bbox_fallback({masked_depth_img.count()}px)'
 
             self.get_logger().info(

--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -8,6 +8,7 @@ import rclpy
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CompressedImage, CameraInfo
 from shigure_core_msgs.msg import DetectedObjectList, TrackedObjectList, TrackedObject, Cube
+from bboxes_ex_msgs.msg import Segments
 
 from shigure_core.nodes.node_image_preview import ImagePreviewNode
 from shigure_core.nodes.object_tracking.logic import ObjectTrackingLogic
@@ -42,10 +43,19 @@ class ObjectTrackingNode(ImagePreviewNode):
             qos_profile=shigure_qos
         )
         object_detection_subscriber = message_filters.Subscriber(
-            self, 
-            DetectedObjectList, 
-            '/shigure/object_detection', 
+            self,
+            DetectedObjectList,
+            '/shigure/object_detection',
             qos_profile=shigure_qos
+        )
+
+        # /Segments は TimeSynchronizer に入れず最新を直接キャッシュする
+        self._latest_segments = None
+        self.create_subscription(
+            Segments,
+            '/Segments',
+            self._on_segments,
+            shigure_qos,
         )
 
         if not self.is_debug_mode:
@@ -71,6 +81,52 @@ class ObjectTrackingNode(ImagePreviewNode):
         for i in range(255):
             self._colors.append(tuple([random.randint(128, 192) for _ in range(3)]))
 
+    def _on_segments(self, msg: Segments):
+        self._latest_segments = msg
+
+    @staticmethod
+    def _bbox_iou(a, b) -> float:
+        ax1, ay1, ax2, ay2 = a
+        bx1, by1, bx2, by2 = b
+        ix1 = max(ax1, bx1); iy1 = max(ay1, by1)
+        ix2 = min(ax2, bx2); iy2 = min(ay2, by2)
+        iw = max(0, ix2 - ix1); ih = max(0, iy2 - iy1)
+        inter = iw * ih
+        if inter == 0:
+            return 0.0
+        area_a = max(0, ax2 - ax1) * max(0, ay2 - ay1)
+        area_b = max(0, bx2 - bx1) * max(0, by2 - by1)
+        union = area_a + area_b - inter
+        return float(inter) / float(union) if union > 0 else 0.0
+
+    def _build_fresh_bbox_mask(self, bbox_x, bbox_y, bbox_w, bbox_h, img_h, img_w):
+        """最新の /Segments から該当 BBOX 用のバイナリマスクを生成する。
+        見つからなければ None を返す。"""
+        if self._latest_segments is None:
+            return None, None
+        best_seg = None
+        best_iou = 0.0
+        bbox_a = (float(bbox_x), float(bbox_y), float(bbox_x + bbox_w), float(bbox_y + bbox_h))
+        for seg in self._latest_segments.segments:
+            if len(seg.x_masks) == 0 or len(seg.x_masks) != len(seg.y_masks):
+                continue
+            iou = self._bbox_iou(bbox_a, (float(seg.xmin), float(seg.ymin), float(seg.xmax), float(seg.ymax)))
+            if iou > best_iou:
+                best_iou = iou
+                best_seg = seg
+        if best_seg is None or best_iou < 0.3:
+            return None, best_iou
+        # x_masks/y_masks は (row, col)=(y, x) 順なので入れ替え
+        pts = np.stack([np.asarray(best_seg.y_masks, dtype=np.int32),
+                        np.asarray(best_seg.x_masks, dtype=np.int32)], axis=1).reshape(-1, 1, 2)
+        full_mask = np.zeros((img_h, img_w), dtype=np.uint8)
+        cv2.fillPoly(full_mask, [pts], 255)
+        x1 = max(0, min(int(bbox_x), img_w - 1))
+        y1 = max(0, min(int(bbox_y), img_h - 1))
+        x2 = max(x1 + 1, min(int(bbox_x + bbox_w), img_w))
+        y2 = max(y1 + 1, min(int(bbox_y + bbox_h), img_h))
+        return full_mask[y1:y2, x1:x2], best_iou
+
     def callback(self, depth_src: CompressedImage, detected_object_list: DetectedObjectList,
                  camera_info: CameraInfo):
         self.frame_count_up()
@@ -93,6 +149,7 @@ class ObjectTrackingNode(ImagePreviewNode):
 
         k_inv = np.linalg.inv(k)
         height, width = depth_img.shape[:2]
+        EROSION_PIXELS = 5
         for object_id, item in self._tracking_info.object_dict.items():
             stay_object, bounding_box = item
 
@@ -102,15 +159,78 @@ class ObjectTrackingNode(ImagePreviewNode):
             tracked_object.bounding_box = stay_object.bounding_box
 
             bounding_box = stay_object.bounding_box
-            left = min(int(bounding_box.x), width - 1)
-            top = min(int(bounding_box.y), height - 1)
-            right = min(int(bounding_box.x + bounding_box.width), width - 1)
-            bottom = min(int(bounding_box.y + bounding_box.height), height - 1)
+            left = max(0, min(int(bounding_box.x), width - 1))
+            top = max(0, min(int(bounding_box.y), height - 1))
+            right = max(left + 1, min(int(bounding_box.x + bounding_box.width), width))
+            bottom = max(top + 1, min(int(bounding_box.y + bounding_box.height), height))
 
-            masked_depth_img = np.ma.masked_equal(depth_img[top:bottom, left:right], 0.0, copy=False)
+            depth_roi = depth_img[top:bottom, left:right]
 
-            depth_min = masked_depth_img.min()
-            depth_max = masked_depth_img.max()
+            # まず最新 /Segments から BBOX に対応するマスクを再生成 (毎フレーム最新)
+            seg_mask = None
+            fresh_mask, fresh_iou = self._build_fresh_bbox_mask(
+                bounding_box.x, bounding_box.y, bounding_box.width, bounding_box.height,
+                height, width,
+            )
+            mask_source = 'none'
+            if fresh_mask is not None:
+                if fresh_mask.shape[:2] != depth_roi.shape[:2]:
+                    fresh_mask = cv2.resize(fresh_mask, (depth_roi.shape[1], depth_roi.shape[0]),
+                                            interpolation=cv2.INTER_NEAREST)
+                seg_mask = (fresh_mask > 0).astype(np.uint8) * 255
+                mask_source = f'fresh(iou={fresh_iou:.2f})'
+            elif stay_object.mask is not None and len(stay_object.mask.data) > 0:
+                try:
+                    decoded = self.bridge.compressed_imgmsg_to_cv2(stay_object.mask)
+                    if decoded.ndim == 3:
+                        decoded = cv2.cvtColor(decoded, cv2.COLOR_BGR2GRAY)
+                    if decoded.shape[:2] != depth_roi.shape[:2]:
+                        decoded = cv2.resize(decoded, (depth_roi.shape[1], depth_roi.shape[0]),
+                                             interpolation=cv2.INTER_NEAREST)
+                    seg_mask = (decoded > 0).astype(np.uint8) * 255
+                    mask_source = 'stale_msg'
+                except Exception as e:
+                    self.get_logger().warning(f'mask decode failed for {object_id}: {e}')
+                    seg_mask = None
+
+            depth_min = None
+            depth_max = None
+            path_taken = 'none'
+            mask_coverage = 0.0
+            depth_stats_log = ''
+            if seg_mask is not None:
+                mask_coverage = float((seg_mask > 0).sum()) / max(1, seg_mask.size)
+                kernel_size = EROSION_PIXELS * 2 + 1
+                kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
+                eroded_mask = cv2.erode(seg_mask, kernel, iterations=1)
+                valid = (eroded_mask > 0) & (depth_roi > 0)
+                if valid.any():
+                    vals = depth_roi[valid]
+                    depth_min = float(vals.min())
+                    depth_max = float(vals.max())
+                    p5, p50, p95 = np.percentile(vals, [5, 50, 95])
+                    depth_stats_log = f' p5={p5:.0f} median={p50:.0f} p95={p95:.0f}'
+                    path_taken = f'eroded({valid.sum()}px)'
+                else:
+                    valid_fallback = (seg_mask > 0) & (depth_roi > 0)
+                    if valid_fallback.any():
+                        depth_min = float(depth_roi[valid_fallback].min())
+                        depth_max = float(depth_roi[valid_fallback].max())
+                        path_taken = f'mask_only({valid_fallback.sum()}px)'
+
+            if depth_min is None or depth_max is None:
+                masked_depth_img = np.ma.masked_equal(depth_roi, 0.0, copy=False)
+                if masked_depth_img.count() == 0:
+                    continue
+                depth_min = float(masked_depth_img.min())
+                depth_max = float(masked_depth_img.max())
+                path_taken = f'bbox_fallback({masked_depth_img.count()}px)'
+
+            self.get_logger().info(
+                f'[{object_id}] mask={mask_source} path={path_taken} mask_cov={mask_coverage:.2f} '
+                f'roi={depth_roi.shape} dmin={depth_min:.0f} dmax={depth_max:.0f} '
+                f'depth_range={depth_max - depth_min:.0f}mm{depth_stats_log}'
+            )
 
             s1 = np.asarray([[bounding_box.x, bounding_box.y, 1]]).T
             s2 = np.asarray([[bounding_box.x + bounding_box.width,

--- a/shigure_core/shigure_core/nodes/node_raycast_hit_detection.py
+++ b/shigure_core/shigure_core/nodes/node_raycast_hit_detection.py
@@ -104,6 +104,60 @@ class RaycastHitDetectionNode(ImagePreviewNode):
         self.pos = PointStamped()
         #----------------------------------------------------------------------------------------------------
     
+    def _transform_cube_to_hololens_aabb(self, collider, trans):
+        """camera 座標系で AABB として定義された Cube(単位: mm)を、
+        hololens_origin 座標系における AABB(単位: m)に変換する。
+
+        手法: 8頂点を全て do_transform_point で変換し、変換後の点群から
+        hololens 軸並行の min/max を取って AABB を再構成する。
+        camera 軸 と hololens 軸 が非平行な場合、本来の OBB を覆う最小 AABB
+        になる(=寸法が若干大きめに出る)が、向きズレ・上下逆転・回転ズレは
+        この方法で全て解消する。
+
+        Returns: (x, y, z, width, height, depth) tuple in meters.
+        """
+        # mm→m に変換しつつ 8 隅を列挙
+        x0 = collider.x / 1000.0
+        y0 = collider.y / 1000.0
+        z0 = collider.z / 1000.0
+        w = collider.width / 1000.0
+        h = collider.height / 1000.0
+        d = collider.depth / 1000.0
+
+        corners_camera = (
+            (x0,     y0,     z0    ),
+            (x0 + w, y0,     z0    ),
+            (x0,     y0 + h, z0    ),
+            (x0 + w, y0 + h, z0    ),
+            (x0,     y0,     z0 + d),
+            (x0 + w, y0,     z0 + d),
+            (x0,     y0 + h, z0 + d),
+            (x0 + w, y0 + h, z0 + d),
+        )
+
+        pt = PointStamped()
+        xs, ys, zs = [], [], []
+        for cx, cy, cz in corners_camera:
+            pt.point.x = cx
+            pt.point.y = cy
+            pt.point.z = cz
+            transformed = tf2_geometry_msgs.do_transform_point(pt, trans)
+            xs.append(transformed.point.x)
+            ys.append(transformed.point.y)
+            zs.append(transformed.point.z)
+
+        aabb_x = min(xs)
+        aabb_y = min(ys)
+        aabb_z = min(zs)
+        return (
+            aabb_x,
+            aabb_y,
+            aabb_z,
+            max(xs) - aabb_x,
+            max(ys) - aabb_y,
+            max(zs) - aabb_z,
+        )
+
     def callback(self, object_list: TrackedObjectList, hit_point: PointStamped, color_img_src: CompressedImage, camera_info: CameraInfo):
         self.get_logger().info('Messages synchronized')
         self.get_logger().info('Received position: x=%f, y=%f, z=%f' % (hit_point.point.x, hit_point.point.y, hit_point.point.z))
@@ -120,17 +174,13 @@ class RaycastHitDetectionNode(ImagePreviewNode):
                 
                 #----------------------------------------------------------------------------------------------------
                 trans = self._tf_buffer.lookup_transform(self.to_frame_name, self.from_frame_name, rclpy.time.Time())
-                self.pos.point.x = tracked_object.collider.x / 1000
-                self.pos.point.y = tracked_object.collider.y / 1000
-                self.pos.point.z = tracked_object.collider.z / 1000
-
-                transformed_point = tf2_geometry_msgs.do_transform_point(self.pos, trans)
-                tracked_object.collider.x = transformed_point.point.x
-                tracked_object.collider.y = transformed_point.point.y
-                tracked_object.collider.z = transformed_point.point.z 
-                tracked_object.collider.width = tracked_object.collider.width / 1000
-                tracked_object.collider.height = tracked_object.collider.height / 1000
-                tracked_object.collider.depth = tracked_object.collider.depth / 4000
+                ax, ay, az, aw, ah, ad = self._transform_cube_to_hololens_aabb(tracked_object.collider, trans)
+                tracked_object.collider.x = ax
+                tracked_object.collider.y = ay
+                tracked_object.collider.z = az
+                tracked_object.collider.width = aw
+                tracked_object.collider.height = ah
+                tracked_object.collider.depth = ad
                 print({'collider.x': tracked_object.collider.x, 'collider.y': tracked_object.collider.y, 'collider.z': tracked_object.collider.z, 'width': tracked_object.collider.width,
                        'height': tracked_object.collider.height, 'depth': tracked_object.collider.depth})
                 #----------------------------------------------------------------------------------------------------
@@ -161,17 +211,13 @@ class RaycastHitDetectionNode(ImagePreviewNode):
 
         for tracked_object in object_list.tracked_object_list:
             trans = self._tf_buffer.lookup_transform(self.to_frame_name, self.from_frame_name, rclpy.time.Time())
-            self.pos.point.x = tracked_object.collider.x / 1000
-            self.pos.point.y = tracked_object.collider.y / 1000
-            self.pos.point.z = tracked_object.collider.z / 1000
-            transformed_point = tf2_geometry_msgs.do_transform_point(self.pos, trans)
-
-            tracked_object.collider.x = transformed_point.point.x
-            tracked_object.collider.y = transformed_point.point.y
-            tracked_object.collider.z = transformed_point.point.z
-            tracked_object.collider.width = tracked_object.collider.width / 1000
-            tracked_object.collider.height = tracked_object.collider.height / 1000
-            tracked_object.collider.depth = tracked_object.collider.depth / 4000
+            ax, ay, az, aw, ah, ad = self._transform_cube_to_hololens_aabb(tracked_object.collider, trans)
+            tracked_object.collider.x = ax
+            tracked_object.collider.y = ay
+            tracked_object.collider.z = az
+            tracked_object.collider.width = aw
+            tracked_object.collider.height = ah
+            tracked_object.collider.depth = ad
             
             #-------------------------------------------
             debug_msg = Point()

--- a/shigure_core/shigure_core/nodes/node_yolox_object_detection.py
+++ b/shigure_core/shigure_core/nodes/node_yolox_object_detection.py
@@ -13,7 +13,7 @@ from rcl_interfaces.msg import ParameterDescriptor, ParameterType
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import Image, CompressedImage, CameraInfo
 from shigure_core_msgs.msg import DetectedObjectList, DetectedObject, BoundingBox,PoseKeyPointsList
-from bboxes_ex_msgs.msg import BoundingBoxes
+from bboxes_ex_msgs.msg import BoundingBoxes, Segments
 
 
 
@@ -42,32 +42,38 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 			10
 		)
 		yolox_bbox_subscriber = message_filters.Subscriber(
-			self, 
+			self,
 			BoundingBoxes,
 			'/bounding_boxes',
 			qos_profile = shigure_qos
 		)
 		people_subscriber = message_filters.Subscriber(
-			self, 
-			 PoseKeyPointsList, 
-			'/shigure/people_detection', 
+			self,
+			 PoseKeyPointsList,
+			'/shigure/people_detection',
+			qos_profile=shigure_qos
+		)
+		segments_subscriber = message_filters.Subscriber(
+			self,
+			Segments,
+			'/Segments',
 			qos_profile=shigure_qos
 		)
 		color_subscriber = message_filters.Subscriber(
-			self, 
+			self,
 			CompressedImage,
-			'/rs/color/compressed', 
+			'/rs/color/compressed',
 			qos_profile = shigure_qos
 		)
 		depth_camera_info_subscriber = message_filters.Subscriber(
-			self, 
+			self,
 			CameraInfo,
-			'/rs/aligned_depth_to_color/cameraInfo', 
+			'/rs/aligned_depth_to_color/cameraInfo',
 			qos_profile=shigure_qos
 		)
-		
+
 		self.time_synchronizer = message_filters.TimeSynchronizer(
-			[yolox_bbox_subscriber,people_subscriber, color_subscriber, depth_camera_info_subscriber], 1000)
+			[yolox_bbox_subscriber, people_subscriber, segments_subscriber, color_subscriber, depth_camera_info_subscriber], 1000)
 		self.time_synchronizer.registerCallback(self.callback)
 		
 		self.yolox_object_detection_logic = YoloxObjectDetectionLogic()
@@ -89,13 +95,23 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 		self._colors = []
 		for i in range(255):
 			self._colors.append(tuple([random.randint(128, 192) for _ in range(3)]))
-		
-		
+
+		self._class_color_cache: dict = {}
+
 		self.object_index = 0
 		
-	def callback(self, yolox_bbox_src: BoundingBoxes,people: PoseKeyPointsList, color_img_src: CompressedImage, camera_info: CameraInfo):
+	def callback(self, yolox_bbox_src: BoundingBoxes, people: PoseKeyPointsList, segments_src: Segments, color_img_src: CompressedImage, camera_info: CameraInfo):
 		self.get_logger().info('Buffering start', once=True)
 		self.frame_count_up()
+
+		# 毎フレーム診断: bbox側とsegments側のクラス内訳
+		bbox_classes = [b.class_id for b in yolox_bbox_src.bounding_boxes]
+		seg_classes = [s.class_id for s in segments_src.segments]
+		self.get_logger().info(
+			f'[diag] bbox_classes={bbox_classes} seg_classes={seg_classes} '
+			f'frame_objs={len(self.frame_object_list)}'
+		)
+
 		color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_img_src)
 		height, width = color_img.shape[:2]
 		if not hasattr(self, 'object_list'):
@@ -154,8 +170,8 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 		# 	if not all([frame_object.is_finished() for frame_object in frame_object_list]):
 		# 		self.get_logger().warning('検知が終了していないオブジェクトを含んでいます')
 
-		if self.frame_object_list:		
-			detected_object_list = self.create_msg(self.frame_object_list, detected_object_list, frame)
+		if self.frame_object_list:
+			detected_object_list = self.create_msg(self.frame_object_list, detected_object_list, frame, segments_src, color_img.shape[:2])
 		
 		self.detection_publisher.publish(detected_object_list)
 
@@ -164,7 +180,24 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 
 			result_img = color_img.copy()
 			yolox_img = color_img.copy()
-			
+
+			# セグメンテーション結果を YOLO 検出側 (yolox_img) に重ねる
+			seg_overlay = yolox_img.copy()
+			for seg in segments_src.segments:
+				if len(seg.x_masks) == 0 or len(seg.x_masks) != len(seg.y_masks):
+					continue
+				# x_masks/y_masks は (row, col)=(y, x) 順で格納されているため入れ替え
+				pts = np.stack([np.asarray(seg.y_masks, dtype=np.int32),
+								np.asarray(seg.x_masks, dtype=np.int32)], axis=1).reshape(-1, 1, 2)
+				color = self._color_for_class(seg.class_id)
+				cv2.fillPoly(seg_overlay, [pts], color)
+				cv2.polylines(yolox_img, [pts], isClosed=True, color=color, thickness=2)
+				label = f"{seg.class_id} {seg.probability:.2f}"
+				label_y = max(int(seg.ymin) - 4, 12)
+				cv2.putText(yolox_img, label, (int(seg.xmin), label_y),
+							cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 2, cv2.LINE_AA)
+			yolox_img = cv2.addWeighted(seg_overlay, 0.4, yolox_img, 0.6, 0)
+
 			#for s_item in start_item_list:
 				#bounding_box_src = s_item._bounding_box
 				#x, y, width, height = bounding_box_src.items
@@ -280,14 +313,78 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 			
 			
 				
-	def  create_msg(self, frame_object_list: List[FrameObject], detected_object_list: DetectedObjectList, frame: ColorImageFrame) -> DetectedObjectList:
+	def _color_for_class(self, class_id: str) -> tuple:
+		if class_id not in self._class_color_cache:
+			rng = np.random.default_rng(abs(hash(class_id)) % (2**32))
+			self._class_color_cache[class_id] = tuple(int(v) for v in rng.integers(64, 256, size=3))
+		return self._class_color_cache[class_id]
+
+	@staticmethod
+	def _rasterize_segment_to_bbox_mask(seg, img_h: int, img_w: int, x: int, y: int, width: int, height: int) -> np.ndarray:
+		# x_masks/y_masks は (row, col)=(y, x) 順で格納されているため入れ替えてポリゴン化する
+		pts = np.stack([np.asarray(seg.y_masks, dtype=np.int32),
+						np.asarray(seg.x_masks, dtype=np.int32)], axis=1)
+		full_mask = np.zeros((img_h, img_w), dtype=np.uint8)
+		cv2.fillPoly(full_mask, [pts], 255)
+		x1 = max(0, min(int(x), img_w - 1))
+		y1 = max(0, min(int(y), img_h - 1))
+		x2 = max(x1 + 1, min(int(x + width), img_w))
+		y2 = max(y1 + 1, min(int(y + height), img_h))
+		return full_mask[y1:y2, x1:x2]
+
+	@staticmethod
+	def _bbox_iou(a, b) -> float:
+		ax1, ay1, ax2, ay2 = a
+		bx1, by1, bx2, by2 = b
+		ix1 = max(ax1, bx1); iy1 = max(ay1, by1)
+		ix2 = min(ax2, bx2); iy2 = min(ay2, by2)
+		iw = max(0, ix2 - ix1); ih = max(0, iy2 - iy1)
+		inter = iw * ih
+		if inter == 0:
+			return 0.0
+		area_a = max(0, ax2 - ax1) * max(0, ay2 - ay1)
+		area_b = max(0, bx2 - bx1) * max(0, by2 - by1)
+		union = area_a + area_b - inter
+		return float(inter) / float(union) if union > 0 else 0.0
+
+	def _find_matching_segment(self, class_id: str, x: int, y: int, width: int, height: int, segments_src: Segments):
+		best_seg = None
+		best_iou = 0.0
+		bbox_a = (x, y, x + width, y + height)
+		for seg in segments_src.segments:
+			if seg.class_id != class_id:
+				continue
+			if len(seg.x_masks) == 0 or len(seg.x_masks) != len(seg.y_masks):
+				continue
+			iou = self._bbox_iou(bbox_a, (int(seg.xmin), int(seg.ymin), int(seg.xmax), int(seg.ymax)))
+			if iou > best_iou:
+				best_iou = iou
+				best_seg = seg
+		return best_seg if best_iou > 0.3 else None
+
+	def create_msg(self, frame_object_list: List[FrameObject], detected_object_list: DetectedObjectList, frame: ColorImageFrame, segments_src: Segments, img_shape) -> DetectedObjectList:
+		img_h, img_w = img_shape
 		for frame_object in frame_object_list:
 			action, bounding_box_src, size, mask_img, time, class_id= frame_object.item.items
 			x, y, width, height = bounding_box_src.items
-			
+
+			seg = self._find_matching_segment(class_id, x, y, width, height, segments_src)
+			if seg is not None:
+				bbox_mask = self._rasterize_segment_to_bbox_mask(seg, img_h, img_w, x, y, width, height)
+				self.get_logger().info(
+					f'[match] class={class_id} bbox=({x},{y},{width}x{height}) '
+					f'seg_classes={[s.class_id for s in segments_src.segments]}'
+				)
+			else:
+				bbox_mask = np.full((max(1, int(height)), max(1, int(width))), 255, dtype=np.uint8)
+				self.get_logger().warning(
+					f'[NO match] class={class_id} bbox=({x},{y},{width}x{height}) '
+					f'seg_classes={[s.class_id for s in segments_src.segments]}'
+				)
+
 			detected_object = DetectedObject()
 			detected_object.action = action.value
-			detected_object.mask = self.bridge.cv2_to_compressed_imgmsg(mask_img, 'png')
+			detected_object.mask = self.bridge.cv2_to_compressed_imgmsg(bbox_mask, 'png')
 			#print(detected_object.action)
 			bounding_box = BoundingBox()
 			bounding_box.x = float(x)

--- a/shigure_core/shigure_core/nodes/yolox_object_detection/logic.py
+++ b/shigure_core/shigure_core/nodes/yolox_object_detection/logic.py
@@ -41,8 +41,10 @@ class YoloxObjectDetectionLogic:
                 bool: 物体と思われるものの規定の物体でないものかどうか
             """
             #DEFAULT_OBJECTS = []
-            DEFAULT_OBJECTS = ['person','dog','cat','chair','laptop','tv','microwave','refrigerator','potted plant','cup','keyboard','couch','mouse','sink','dining table','skateboard',"book","banana","backpack","toy","backpack"]
-            if class_id == 'stuffed toy':
+            DEFAULT_OBJECTS = ['person','dog','cat','chair','laptop','tv','microwave','refrigerator','potted plant','cup','keyboard','couch','mouse','sink','dining table','skateboard','book','banana','backpack']
+            # ぬいぐるみ系は確信度が揺らぎやすいので閾値を下げる
+            # ('stuffed toy' は YOLOX 独自学習版のクラス名、'teddy bear' は YOLO11/COCO 標準名)
+            if class_id in ('teddy bear', 'stuffed toy'):
                 is_object: bool = probability > object_threshold
             else:
                 is_object: bool = probability > 0.30
@@ -233,7 +235,11 @@ class YoloxObjectDetectionLogic:
                                 x = np.clip(int(pixel_point.x), 0, img_width - 1)
                                 y = np.clip(int(pixel_point.y), 0, img_height - 1)
                                 
-                                POSE_PAIRS:List[List[int]] =  [ [1,0],[1,2],[1,5],[2,3],[3,4],[5,6],[6,7],[1,8],[8,9],[8,12],[9,10],[10,11],[11,22],[11,24],[12,13],[13,14],[14,19],[14,21],[15,0],[15,17],[16,0],[16,18],[19,20],[22,11],[22,23]]
+                                # 遮蔽判定は腕の骨格(肩-肘-手首)に限定する。
+                                # 胴体や脚・顔の骨格を含めると、人物が物体の前に立つだけで
+                                # 「物体が手で隠されている」と誤判定して TAKE_OUT が発火しなくなる。
+                                # 手首が未検出でも [2,3]/[5,6] の肩-肘で腕の指向は捉えられる。
+                                POSE_PAIRS:List[List[int]] = [[2,3], [3,4], [5,6], [6,7]]
                                 # Draw Skeleton
                                 for pair in POSE_PAIRS:
                                     partA:int  = pair[0]
@@ -291,7 +297,11 @@ class YoloxObjectDetectionLogic:
                                 x = np.clip(int(pixel_point.x), 0, img_width - 1)
                                 y = np.clip(int(pixel_point.y), 0, img_height - 1)
                                 
-                                POSE_PAIRS:List[List[int]] =  [ [1,0],[1,2],[1,5],[2,3],[3,4],[5,6],[6,7],[1,8],[8,9],[8,12],[9,10],[10,11],[11,22],[11,24],[12,13],[13,14],[14,19],[14,21],[15,0],[15,17],[16,0],[16,18],[19,20],[22,11],[22,23]]
+                                # 遮蔽判定は腕の骨格(肩-肘-手首)に限定する。
+                                # 胴体や脚・顔の骨格を含めると、人物が物体の前に立つだけで
+                                # 「物体が手で隠されている」と誤判定して TAKE_OUT が発火しなくなる。
+                                # 手首が未検出でも [2,3]/[5,6] の肩-肘で腕の指向は捉えられる。
+                                POSE_PAIRS:List[List[int]] = [[2,3], [3,4], [5,6], [6,7]]
                                 # Draw Skeleton
                                 for pair in POSE_PAIRS:
                                     partA:int  = pair[0]


### PR DESCRIPTION
・東さんのYOLO11(セグメンテーションモデル)の出力をsubscribeできるようにした
・セグメンテーション情報を使った物体クロップ&深度取得
・外れ値を除くため深度分布5%の値を最低値，95%の値を最大値に変更
・追加訓練されたYOLOXとYOLO11のクラス名の整合性の確保