### PR TITLE
2026_demoからpull，物体検出部の変更，物体深度最大値/最小値取得ロジック変更，クラスID名修正

### DIFF
--- a/shigure_core/shigure_core/launch/shigure_core_rtps_hololens_launch.py
+++ b/shigure_core/shigure_core/launch/shigure_core_rtps_hololens_launch.py
@@ -10,32 +10,14 @@ def generate_launch_description():
 
     return LaunchDescription([
         SetEnvironmentVariable(name='FASTRTPS_DEFAULT_PROFILES_FILE', value=str(rtps_path)),
+        # YOLO11 ベースの物体検出ノード。旧来の深度差分パイプライン
+        # (bg_subtraction -> subtraction_analysis -> object_detection) を置き換える。
         Node(
             package="shigure_core",
-            executable="bg_subtraction",
-            #prefix="gnome-terminal --tab -t 'bg_subtraction' -- bash -c 'echo '$FASTRTPS_DEFAULT_PROFILES_FILE';bash' --",
-            prefix="gnome-terminal --tab -t 'bg_subtraction' --",
+            executable="yolox_object_detection",
+            prefix="gnome-terminal --tab -t 'yolox_object_detection' --",
             parameters=[
-                {"is_debug_mode": False},
-                {"input_round":1500},
-                {"avg_round":1500},
-                {"sd_round":500},
-            ],
-        ),
-        Node(
-            package="shigure_core",
-            executable="subtraction_analysis",
-            prefix="gnome-terminal --tab -t 'subtraction_analysis' --",
-            parameters=[
-                {"is_debug_mode": False},
-            ],
-        ),
-        Node(
-            package="shigure_core",
-            executable="object_detection",
-            prefix="gnome-terminal --tab -t 'object_detection' --",
-            parameters=[
-                {"is_debug_mode": False},
+                {"is_debug_mode": True},
             ],
         ),
         Node(

--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -71,6 +71,46 @@ class ObjectTrackingNode(ImagePreviewNode):
         for i in range(255):
             self._colors.append(tuple([random.randint(128, 192) for _ in range(3)]))
 
+    def _compute_depth_range(self, depth_img: np.ndarray, stay_object, left: int, top: int,
+                             right: int, bottom: int):
+        """3次元BBOXの奥行きに用いる深度範囲を求めます.
+
+        物体領域(セグメンテーションマスク)の縁から5pxより更に内部の深度値のうち,
+        分布の5%点を最小値, 95%点を最大値として返します. マスクが取得できない,
+        または内部に有効な深度が無い場合は bbox 内の深度最小/最大にフォールバックします.
+        """
+        depth_roi = depth_img[top:bottom, left:right]
+
+        mask_roi = None
+        try:
+            mask = self.bridge.compressed_imgmsg_to_cv2(stay_object.mask)
+            if mask is not None and mask.ndim == 2:
+                # マスクは bbox 左上を原点とする. depth_roi の大きさに合わせて切り出す
+                mask_roi = mask[0:depth_roi.shape[0], 0:depth_roi.shape[1]]
+        except Exception:
+            mask_roi = None
+
+        valid = None
+        if mask_roi is not None and mask_roi.shape == depth_roi.shape and mask_roi.any():
+            binary = (mask_roi > 0).astype(np.uint8)
+            # 縁から5pxより内部のみを残す (11x11カーネルで縁を5px収縮)
+            kernel = np.ones((11, 11), np.uint8)
+            interior_mask = cv2.erode(binary, kernel)
+            interior = (interior_mask > 0) & (depth_roi != 0.0)
+            if np.count_nonzero(interior) > 0:
+                valid = depth_roi[interior]
+
+        if valid is None or valid.size == 0:
+            # フォールバック: 従来通り bbox 内の有効深度の最小/最大を用いる
+            masked = np.ma.masked_equal(depth_roi, 0.0, copy=False)
+            if masked.count() == 0:
+                return 0.0, 0.0
+            return float(masked.min()), float(masked.max())
+
+        depth_min = float(np.percentile(valid, 5))
+        depth_max = float(np.percentile(valid, 95))
+        return depth_min, depth_max
+
     def callback(self, depth_src: CompressedImage, detected_object_list: DetectedObjectList,
                  camera_info: CameraInfo):
         self.frame_count_up()
@@ -107,10 +147,7 @@ class ObjectTrackingNode(ImagePreviewNode):
             right = min(int(bounding_box.x + bounding_box.width), width - 1)
             bottom = min(int(bounding_box.y + bounding_box.height), height - 1)
 
-            masked_depth_img = np.ma.masked_equal(depth_img[top:bottom, left:right], 0.0, copy=False)
-
-            depth_min = masked_depth_img.min()
-            depth_max = masked_depth_img.max()
+            depth_min, depth_max = self._compute_depth_range(depth_img, stay_object, left, top, right, bottom)
 
             s1 = np.asarray([[bounding_box.x, bounding_box.y, 1]]).T
             s2 = np.asarray([[bounding_box.x + bounding_box.width,

--- a/shigure_core/shigure_core/nodes/node_yolox_object_detection.py
+++ b/shigure_core/shigure_core/nodes/node_yolox_object_detection.py
@@ -8,7 +8,7 @@ from rcl_interfaces.msg import Parameter
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CompressedImage, CameraInfo
 from shigure_core_msgs.msg import DetectedObjectList, DetectedObject, BoundingBox, PoseKeyPointsList
-from bboxes_ex_msgs.msg import BoundingBoxes
+from bboxes_ex_msgs.msg import BoundingBoxes, Segments
 
 
 
@@ -32,9 +32,15 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 			10
 		)
 		yolox_bbox_subscriber = message_filters.Subscriber(
-			self, 
+			self,
 			BoundingBoxes,
 			'/bounding_boxes',
+			qos_profile = shigure_qos
+		)
+		segment_subscriber = message_filters.Subscriber(
+			self,
+			Segments,
+			'/Segments',
 			qos_profile = shigure_qos
 		)
 		people_subscriber = message_filters.Subscriber(
@@ -56,8 +62,9 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 			qos_profile=shigure_qos
 		)
 		
+	
 		self.time_synchronizer = message_filters.TimeSynchronizer(
-			[yolox_bbox_subscriber,people_subscriber, color_subscriber, depth_camera_info_subscriber], 1000)
+			[yolox_bbox_subscriber, segment_subscriber, people_subscriber, color_subscriber, depth_camera_info_subscriber], 1000)
 		self.time_synchronizer.registerCallback(self.callback)
 		
 		self.yolox_object_detection_logic = YoloxObjectDetectionLogic()
@@ -143,16 +150,16 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 				self.get_logger().info(f'BufferSize : {param.value}')
 		return SetParametersResult(successful=True)
 
-	def callback(self, yolox_bbox_src: BoundingBoxes, people: PoseKeyPointsList, color_img_src: CompressedImage, camera_info: CameraInfo):
+	def callback(self, yolox_bbox_src: BoundingBoxes, segments_src: Segments, people: PoseKeyPointsList, color_img_src: CompressedImage, camera_info: CameraInfo):
 		self.get_logger().info('Buffering start', once=True)
 		self.frame_count_up()
 		color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_img_src)
 		sec = color_img_src.header.stamp.sec
 		nano_sec = color_img_src.header.stamp.nanosec
 
-		# ロジックの実行 (yoloxの物体検出結果から，物体の持ち込み/移動/持ち出し<イベント>を判定する)
+		# ロジックの実行 (YOLO11のセグメンテーション結果から，物体の持ち込み/移動/持ち出し<イベント>を判定する)
 		self.yolox_object_detection_logic.execute(
-			yolox_bbox_src, sec, nano_sec, people, color_img,
+			segments_src, sec, nano_sec, people, color_img,
 			self.fhist_size, self.confirm_threshold, self.dismiss_threshold,
 			self.take_out_threshold, self.match_dist_threshold,
 			self.probability_threshold, self.stuffed_toy_threshold
@@ -173,7 +180,7 @@ class YoloxObjectDetectionNode(ImagePreviewNode):
 
 		if self.is_debug_mode:
 			YoloxVisualizer.draw(
-				color_img, yolox_bbox_src,
+				color_img, yolox_bbox_src, segments_src,
 				self.yolox_object_detection_logic.wait_item_list,
 				self.yolox_object_detection_logic.bring_in_list,
 				people, self.frame_object_list

--- a/shigure_core/shigure_core/nodes/yolox_object_detection/logic.py
+++ b/shigure_core/shigure_core/nodes/yolox_object_detection/logic.py
@@ -1,7 +1,8 @@
 from typing import List, Tuple
+import cv2
 import numpy as np
 from shigure_core_msgs.msg import PoseKeyPointsList
-from bboxes_ex_msgs.msg import BoundingBoxes
+from bboxes_ex_msgs.msg import Segments
 
 from shigure_core.enum.detected_object_action_enum import DetectedObjectActionEnum
 from shigure_core.nodes.common_model.timestamp import Timestamp
@@ -52,7 +53,7 @@ class YoloxObjectDetectionLogic:
     def wait_item_list(self) -> List[TrackedObject]:
         return [t for t in self._tracked_objects if t.state == TrackedState.WAITING]
 
-    def execute(self, yolox_bbox: BoundingBoxes, sec: int, nanosec: int, people: PoseKeyPointsList,
+    def execute(self, segments: Segments, sec: int, nanosec: int, people: PoseKeyPointsList,
                 color_img: np.ndarray, fhist_size: int, confirm_threshold: float, dismiss_threshold: float,
                 take_out_threshold: float, match_dist_threshold: int, probability_threshold: float,
                 stuffed_toy_threshold: float) -> None:
@@ -65,7 +66,7 @@ class YoloxObjectDetectionLogic:
         frame = ColorImageFrame(started_at, self._color_img_buffer[0], color_img)
         self._color_img_frames.add(frame)
 
-        detections = self._parse_detections(yolox_bbox, color_img, started_at, probability_threshold,
+        detections = self._parse_detections(segments, color_img, started_at, probability_threshold,
                                            stuffed_toy_threshold)
 
         matched: set = set()
@@ -236,23 +237,41 @@ class YoloxObjectDetectionLogic:
         return ""
     
     @staticmethod
-    def _parse_detections(yolox_bbox: BoundingBoxes, color_img: np.ndarray, started_at: Timestamp,
+    def _parse_detections(segments: Segments, color_img: np.ndarray, started_at: Timestamp,
                          probability_threshold: float, stuffed_toy_threshold: float) -> List[Detection]:
-        """上流ノードからの yolox_bbox を Detection のリストに変換する"""
+        """YOLO11 ノードからの Segments を Detection のリストに変換する.
+
+        Segment.x_masks には物体領域の y 座標の頂点が, Segment.y_masks には
+        x 座標の頂点が格納されており, インデックスでペアになっている.
+        """
         detections = []
-        for bbox in yolox_bbox.bounding_boxes:
-            x = bbox.xmin
-            y = bbox.ymin
-            width = bbox.xmax - x
-            height = bbox.ymax - y
-            class_id = bbox.class_id
-            probability = bbox.probability
-            if YoloxObjectDetectionLogic.is_unknown_object(class_id, probability, probability_threshold,
-                                                           stuffed_toy_threshold):
-                mask_img = np.zeros(color_img.shape[:2])
-                mask_img[y:y + height, x:x + width] = 255
-                mask_img = mask_img[y:y + height, x:x + width]
-                detections.append(Detection(BoundingBox(x, y, width, height), class_id, mask_img, started_at))
+        img_height, img_width = color_img.shape[:2]
+        for segment in segments.segments:
+            x = segment.xmin
+            y = segment.ymin
+            width = segment.xmax - x
+            height = segment.ymax - y
+            class_id = segment.class_id
+            probability = segment.probability
+            if not YoloxObjectDetectionLogic.is_unknown_object(class_id, probability, probability_threshold,
+                                                               stuffed_toy_threshold):
+                continue
+
+            # セグメンテーション結果からポリゴンマスクを生成する
+            full_mask = np.zeros((img_height, img_width), dtype=np.uint8)
+            if len(segment.x_masks) >= 3 and len(segment.x_masks) == len(segment.y_masks):
+                # x_masks = y座標, y_masks = x座標 (頂点はインデックスでペア)
+                polygon = np.array(
+                    [[px, py] for px, py in zip(segment.y_masks, segment.x_masks)],
+                    dtype=np.int32,
+                )
+                cv2.fillPoly(full_mask, [polygon], 255)
+            else:
+                # マスク頂点が無い場合は bbox 矩形で代替する
+                full_mask[y:y + height, x:x + width] = 255
+
+            mask_img = full_mask[y:y + height, x:x + width]
+            detections.append(Detection(BoundingBox(x, y, width, height), class_id, mask_img, started_at))
         return detections
 
     @staticmethod
@@ -266,12 +285,14 @@ class YoloxObjectDetectionLogic:
         :param stuffed_toy_threshold: 物体と判定するしきい値（max 1, ぬいぐるみ専用の閾値）
         :return: 物体と思われるものの規定の物体でないものかどうか
         """
+        # YOLO11 (COCO) のクラス名で記述した, 持ち込み/持ち出し判定の対象外とする物体
         DEFAULT_OBJECTS = [
             'person', 'dog', 'cat', 'chair', 'laptop', 'tv', 'microwave', 'refrigerator',
             'potted plant', 'cup', 'keyboard', 'couch', 'mouse', 'sink', 'dining table',
-            'skateboard', 'book', 'banana', 'backpack', 'toy',
+            'skateboard', 'book', 'banana', 'backpack',
         ]
-        if class_id == 'stuffed toy':
+        # YOLO11 ではぬいぐるみが 'teddy bear' として検出される (旧 YOLOX の 'stuffed toy')
+        if class_id == 'teddy bear':
             is_object = probability > stuffed_toy_threshold
         else:
             is_object = probability > probability_threshold

--- a/shigure_core/shigure_core/nodes/yolox_object_detection/visualizer.py
+++ b/shigure_core/shigure_core/nodes/yolox_object_detection/visualizer.py
@@ -2,7 +2,7 @@ from typing import List
 
 import cv2
 import numpy as np
-from bboxes_ex_msgs.msg import BoundingBoxes
+from bboxes_ex_msgs.msg import BoundingBoxes, Segments
 from shigure_core_msgs.msg import PoseKeyPointsList
 
 from shigure_core.enum.detected_object_action_enum import DetectedObjectActionEnum
@@ -24,6 +24,7 @@ class YoloxVisualizer:
     def draw(
         color_img: np.ndarray,
         yolox_bboxes: BoundingBoxes,
+        segments: Segments,
         wait_item_list: List[TrackedObject],
         bring_in_list: List[TrackedObject],
         people: PoseKeyPointsList,
@@ -43,8 +44,24 @@ class YoloxVisualizer:
             cv2.rectangle(result_img, (x, y), (x + w, y + h), (255, 0, 102), thickness=3)
             cv2.putText(result_img, 'BRING', (x + 2, y + 20), cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 0, 102), thickness=3)
 
+        # 左側ウィンドウ: YOLO11 の検出結果(2次元BBOX)を描画する
         for bbox in yolox_bboxes.bounding_boxes:
             cv2.rectangle(yolox_img, (bbox.xmin, bbox.ymin), (bbox.xmax, bbox.ymax), (102, 204, 51), thickness=3)
+
+        # 左側ウィンドウ: YOLO11 のセグメンテーション結果(マスク)を頂点を順々につなげて描画する
+        # x_masks = 物体領域の y 座標の頂点, y_masks = x 座標の頂点 (インデックスでペア)
+        for segment in segments.segments:
+            if len(segment.x_masks) < 2 or len(segment.x_masks) != len(segment.y_masks):
+                continue
+            polygon = np.array(
+                [[px, py] for px, py in zip(segment.y_masks, segment.x_masks)],
+                dtype=np.int32,
+            )
+            cv2.polylines(yolox_img, [polygon], isClosed=True, color=(0, 102, 255), thickness=2)
+            label_x = int(np.clip(segment.xmin, 0, img_width - 1))
+            label_y = int(np.clip(segment.ymin - 5, 0, img_height - 1))
+            cv2.putText(yolox_img, segment.class_id, (label_x, label_y),
+                        cv2.FONT_HERSHEY_PLAIN, 1.5, (0, 102, 255), thickness=2)
 
         for person in people.pose_key_points_list:
             for part in range(len(person.point_data)):

--- a/shigure_core_msgs/msg/Segment.msg
+++ b/shigure_core_msgs/msg/Segment.msg
@@ -1,0 +1,8 @@
+string class_id
+float64 probability
+int32 xmin
+int32 ymin
+int32 xmax
+int32 ymax
+int32[] x_masks
+int32[] y_masks

--- a/shigure_core_msgs/msg/Segments.msg
+++ b/shigure_core_msgs/msg/Segments.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+std_msgs/Header image_header
+Segment[] segments


### PR DESCRIPTION
・2026_demoブランチからpullし，それを修正
・物体検出部をYOLO11-segモデルに変更(YOLO11コンテナはiridium.cv.localで稼働中)
・/Segmentsトピック内に流れる検出物体の領域分割結果を取得するように変更
・各物体領域内(正確には縁から5pixel以内)の深度分布から物体深度の最大値(深度値分布の95%の値)と最小値(深度値分布の5%の値)を取得
・追加学習YOLOXとYOLO11のクラス名テーブルの違いを修正(stuffed toy→teddy bear)