### PR TITLE
細谷くんの顔認証&事前顔登録機能&Fast APIを介したWebUIの統合，/shigure/people_detectionトピックに流れる情報に「顔の名前情報」を追加，メッセージ型の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,20 @@ shigure_core/resource/db/Dockerfile_migration
 shigure_core/shigure_core/nodes/past_record_script/
 shigure_core/shigure_core/nodes/yolox_object_detection/logic.py_sample
 
+# ===== 顔認識データ（個人データ・絶対にコミットしない） =====
+# 顔画像・特徴ベクトル・PCAモデルなどの辞書データ一式。
+# 実データは既定で ~/.shigure/face_models（リポジトリ外）に置く運用。
+**/face_models/
+# 追跡デバッグ画像（save_image モードの保存先）
+**/debug_images/
+
+# ===== ビルド/実行時の生成物・キャッシュ =====
+# ROS2 colcon の生成物
+build/
+install/
+log/
+# Python バイトコードキャッシュ
+__pycache__/
+*.py[cod]
+*.egg-info/
+

--- a/shigure_api/package.xml
+++ b/shigure_api/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>shigure_api</name>
+  <version>0.0.1</version>
+  <description>FastAPI bridge for Shigure face recognition events (iOS / React Native)</description>
+  <maintainer email="is0436er@ed.ritsumei.ac.jp">Yukiho-YOSHIEDA</maintainer>
+  <license>MIT License</license>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>shigure_core</exec_depend>
+  <exec_depend>shigure_core_msgs</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/shigure_api/requirements.txt
+++ b/shigure_api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+numpy>=1.24.0
+pydantic>=2.0.0
+Pillow>=9.0.0

--- a/shigure_api/setup.cfg
+++ b/shigure_api/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/shigure_api
+[install]
+install_scripts=$base/lib/shigure_api

--- a/shigure_api/setup.py
+++ b/shigure_api/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+package_name = 'shigure_api'
+
+setup(
+    name=package_name,
+    version='0.0.1',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Yukiho-YOSHIEDA',
+    maintainer_email='is0436er@ed.ritsumei.ac.jp',
+    description='FastAPI bridge for Shigure face recognition events',
+    license='MIT License',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'shigure_api = shigure_api.main:main',
+        ],
+    },
+)

--- a/shigure_api/shigure_api/__init__.py
+++ b/shigure_api/shigure_api/__init__.py
@@ -1,0 +1,1 @@
+"""Shigure FastAPI bridge for iOS / React Native."""

--- a/shigure_api/shigure_api/app.py
+++ b/shigure_api/shigure_api/app.py
@@ -1,0 +1,245 @@
+"""FastAPI application: WebSocket events + REST user list."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator, List, Set
+
+from fastapi import FastAPI, Header, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
+
+from shigure_api.config import API_KEY, FACE_MODELS_DIR, PCA_REDRAW_EVERY, PCA_TRAJECTORY_MAX_POINTS, default_pca_model_path
+from shigure_api.events import UserEvent, UserSummary, user_event_to_dict
+from shigure_api.feature_images import find_face_image_path, load_face_thumbnail
+from shigure_api.pca_plot import PcaPlotHub, PcaPlotStateBuilder
+from shigure_api.tracking_debug import TrackingDebugHub
+
+
+class EventHub:
+    """Broadcast UserEvent to all connected WebSocket clients."""
+
+    def __init__(self) -> None:
+        self._clients: Set[WebSocket] = set()
+        self._lock = asyncio.Lock()
+        self._thread_queue: queue.Queue[UserEvent] = queue.Queue()
+        self._history: List[UserEvent] = []
+        self._history_limit = 100
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def start(self) -> None:
+        self._loop = asyncio.get_running_loop()
+        asyncio.create_task(self._broadcast_loop())
+
+    def enqueue(self, event: UserEvent) -> None:
+        """Thread-safe enqueue from ROS callback thread."""
+        self._thread_queue.put_nowait(event)
+
+    async def _broadcast_loop(self) -> None:
+        while True:
+            event = await asyncio.to_thread(self._thread_queue.get)
+            self._history.append(event)
+            if len(self._history) > self._history_limit:
+                self._history = self._history[-self._history_limit:]
+            payload = user_event_to_dict(event)
+            async with self._lock:
+                dead: List[WebSocket] = []
+                for ws in self._clients:
+                    try:
+                        await ws.send_json(payload)
+                    except Exception:
+                        dead.append(ws)
+                for ws in dead:
+                    self._clients.discard(ws)
+
+    async def connect(self, websocket: WebSocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._clients.add(websocket)
+        for item in self.recent_events(limit=20):
+            await websocket.send_json(item)
+
+    async def disconnect(self, websocket: WebSocket) -> None:
+        async with self._lock:
+            self._clients.discard(websocket)
+
+    def recent_events(self, limit: int = 50) -> List[dict]:
+        return [user_event_to_dict(e) for e in self._history[-limit:]]
+
+
+hub = EventHub()
+pca_hub = PcaPlotHub()
+tracking_debug_hub = TrackingDebugHub()
+pca_builder: PcaPlotStateBuilder | None = None
+
+
+def init_pca_builder(face_models_dir: Path | None = None) -> PcaPlotStateBuilder:
+    global pca_builder
+    base = face_models_dir or FACE_MODELS_DIR
+    pca_builder = PcaPlotStateBuilder(
+        base,
+        default_pca_model_path(base),
+        redraw_every=PCA_REDRAW_EVERY,
+        trajectory_max_points=PCA_TRAJECTORY_MAX_POINTS,
+    )
+    return pca_builder
+
+
+def _resolve_api_key(
+    x_api_key: str | None = None,
+    api_key: str | None = None,
+) -> str | None:
+    return x_api_key or api_key
+
+
+def _verify_api_key(
+    x_api_key: str | None = None,
+    api_key: str | None = None,
+) -> None:
+    if not API_KEY:
+        return
+    if _resolve_api_key(x_api_key, api_key) != API_KEY:
+        raise HTTPException(status_code=401, detail='Invalid API key')
+
+
+def _scan_users(face_models_dir: Path) -> List[UserSummary]:
+    if not face_models_dir.is_dir():
+        return []
+    users: List[UserSummary] = []
+    for user_dir in sorted(face_models_dir.glob('user_*')):
+        if not user_dir.is_dir():
+            continue
+        user_id = user_dir.name
+        frontal = len(list(user_dir.glob('*.npy')))
+        profile_dir = user_dir / 'profile'
+        profile = len(list(profile_dir.glob('*.npy'))) if profile_dir.is_dir() else 0
+        users.append(
+            UserSummary(
+                user_id=user_id,
+                feature_count=frontal,
+                profile_feature_count=profile,
+            )
+        )
+    return users
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    await hub.start()
+    await pca_hub.start()
+    await tracking_debug_hub.start()
+    yield
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title='Shigure API',
+        description='Face recognition events for iOS / React Native clients',
+        version='0.1.0',
+        lifespan=lifespan,
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=['*'],
+        allow_credentials=True,
+        allow_methods=['*'],
+        allow_headers=['*'],
+    )
+
+    @app.get('/health')
+    def health() -> dict:
+        return {
+            'status': 'ok',
+            'face_models_dir': str(FACE_MODELS_DIR),
+            'face_models_exists': FACE_MODELS_DIR.is_dir(),
+        }
+
+    @app.get('/users', response_model=List[UserSummary])
+    def list_users(x_api_key: str | None = Header(default=None, alias='X-API-Key')) -> List[UserSummary]:
+        _verify_api_key(x_api_key)
+        return _scan_users(FACE_MODELS_DIR)
+
+    @app.get('/events/recent')
+    def recent_events(
+        limit: int = 50,
+        x_api_key: str | None = Header(default=None, alias='X-API-Key'),
+    ) -> dict:
+        _verify_api_key(x_api_key)
+        return {'events': hub.recent_events(limit=limit)}
+
+    @app.get('/api/users/{user_id}/features/{feature_num}/face')
+    def get_feature_face(
+        user_id: str,
+        feature_num: int,
+        x_api_key: str | None = Header(default=None, alias='X-API-Key'),
+        api_key: str | None = Query(default=None),
+    ) -> Response:
+        """Return a JPEG thumbnail for face_models/{user_id}/{user_id}_{feature_num}.jpg."""
+        _verify_api_key(x_api_key, api_key)
+        image_path = find_face_image_path(FACE_MODELS_DIR, user_id, feature_num)
+        if image_path is None or not image_path.is_file():
+            raise HTTPException(
+                status_code=404,
+                detail=f'Face image not found for user_id={user_id} feature_num={feature_num}',
+            )
+        try:
+            body = load_face_thumbnail(image_path)
+        except OSError as exc:
+            raise HTTPException(status_code=404, detail=f'Face image unreadable: {exc}') from exc
+        return Response(content=body, media_type='image/jpeg')
+
+    @app.websocket('/ws/events')
+    async def ws_events(websocket: WebSocket) -> None:
+        if API_KEY:
+            key = websocket.query_params.get('api_key')
+            if key != API_KEY:
+                await websocket.close(code=4401, reason='Invalid API key')
+                return
+        await hub.connect(websocket)
+        try:
+            while True:
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            await hub.disconnect(websocket)
+
+    @app.websocket('/ws/pca_plot')
+    async def ws_pca_plot(websocket: WebSocket) -> None:
+        if API_KEY:
+            key = websocket.query_params.get('api_key')
+            if key != API_KEY:
+                await websocket.close(code=4401, reason='Invalid API key')
+                return
+        await pca_hub.connect(websocket)
+        try:
+            while True:
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            await pca_hub.disconnect(websocket)
+
+    @app.websocket('/ws/tracking_debug')
+    async def ws_tracking_debug(websocket: WebSocket) -> None:
+        if API_KEY:
+            key = websocket.query_params.get('api_key')
+            if key != API_KEY:
+                await websocket.close(code=4401, reason='Invalid API key')
+                return
+        await tracking_debug_hub.connect(websocket)
+        try:
+            while True:
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            pass
+        finally:
+            await tracking_debug_hub.disconnect(websocket)
+
+    return app
+
+
+app = create_app()

--- a/shigure_api/shigure_api/config.py
+++ b/shigure_api/shigure_api/config.py
@@ -1,0 +1,51 @@
+"""Configuration for shigure_api."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _default_face_models_dir() -> Path:
+    # SHIGURE_FACE_MODELS_DIR 環境変数があれば最優先。
+    # 無ければ固定の永続パス ~/.shigure/face_models（shigure_core 側ノードの既定と一致させること）。
+    env = os.environ.get('SHIGURE_FACE_MODELS_DIR')
+    if env:
+        return Path(env).expanduser()
+    return Path('~/.shigure/face_models').expanduser()
+
+
+FACE_MODELS_DIR = _default_face_models_dir()
+
+RECOGNITION_SCORE_THRESHOLD = float(os.environ.get('SHIGURE_RECOGNITION_SCORE_THRESHOLD', '0.4'))
+RECOGNITION_DEBOUNCE_SEC = float(os.environ.get('SHIGURE_RECOGNITION_DEBOUNCE_SEC', '30'))
+
+API_HOST = os.environ.get('SHIGURE_API_HOST', '0.0.0.0')
+API_PORT = int(os.environ.get('SHIGURE_API_PORT', '8765'))
+API_KEY = os.environ.get('SHIGURE_API_KEY', '')
+
+DICTIONARY_UPDATE_TOPIC = os.environ.get('SHIGURE_DICTIONARY_UPDATE_TOPIC', '/dictionary_update')
+FACE_RECOGNITION_TOPIC = os.environ.get('SHIGURE_FACE_RECOGNITION_TOPIC', '/face_recognition/results')
+FEATURE_INFO_TOPIC = os.environ.get('SHIGURE_FEATURE_INFO_TOPIC', '/feature_info')
+RECOGNITION_HISTORY_TOPIC = os.environ.get(
+    'SHIGURE_RECOGNITION_HISTORY_TOPIC', '/shigure/recognition_history'
+)
+TRACKING_DEBUG_IMAGE_TOPIC = os.environ.get(
+    'SHIGURE_TRACKING_DEBUG_IMAGE_TOPIC', '/shigure/tracking_debug_image'
+)
+
+PCA_REDRAW_EVERY = int(os.environ.get('SHIGURE_PCA_REDRAW_EVERY', '5'))
+PCA_TRAJECTORY_MAX_POINTS = int(os.environ.get('SHIGURE_PCA_TRAJECTORY_MAX_POINTS', '50'))
+PCA_REBUILD_ON_NEW_USER = os.environ.get('SHIGURE_PCA_REBUILD_ON_NEW_USER', 'true').lower() in (
+    '1',
+    'true',
+    'yes',
+)
+
+
+def default_pca_model_path(face_models_dir: Path | None = None) -> Path:
+    env = os.environ.get('SHIGURE_PCA_MODEL_PATH')
+    if env:
+        return Path(env).expanduser()
+    base = face_models_dir or FACE_MODELS_DIR
+    return base / 'pca_model.pkl'

--- a/shigure_api/shigure_api/events.py
+++ b/shigure_api/shigure_api/events.py
@@ -1,0 +1,89 @@
+"""Event models and ROS message → JSON mapping."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+UserEventType = Literal[
+    'user_registered',
+    'user_confirmed',
+    'user_recognized',
+    'registration_failed',
+]
+
+
+class UserEvent(BaseModel):
+    type: UserEventType
+    user_id: str
+    people_id: Optional[str] = None
+    score: Optional[float] = None
+    message: str
+    timestamp: str = Field(default_factory=lambda: _now_iso())
+
+
+class UserSummary(BaseModel):
+    user_id: str
+    feature_count: int
+    profile_feature_count: int = 0
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def event_from_dictionary_update(people_id: str, name: str) -> Optional[UserEvent]:
+    if not name or name == 'none':
+        return UserEvent(
+            type='registration_failed',
+            user_id='none',
+            people_id=people_id,
+            message=f'ユーザー登録に失敗しました（people_id={people_id}）',
+        )
+    if name.startswith('user_new'):
+        return UserEvent(
+            type='user_registered',
+            user_id=name,
+            people_id=people_id,
+            message=f'新規ユーザー {name} が登録されました',
+        )
+    if name.startswith('user'):
+        return UserEvent(
+            type='user_confirmed',
+            user_id=name,
+            people_id=people_id,
+            message=f'既存ユーザー {name} として認識・確定しました',
+        )
+    return UserEvent(
+        type='user_confirmed',
+        user_id=name,
+        people_id=people_id,
+        message=f'ユーザー {name} が確定しました',
+    )
+
+
+def event_from_face_recognition(face_id: str, score: float) -> Optional[UserEvent]:
+    if face_id.endswith('@profile'):
+        base_id = face_id.replace('@profile', '')
+        if base_id == 'unknown':
+            return None
+        return UserEvent(
+            type='user_recognized',
+            user_id=base_id,
+            score=score,
+            message=f'横顔で {base_id} を認識しました（score={score:.2f}）',
+        )
+    if face_id == 'unknown' or not face_id.startswith('user'):
+        return None
+    return UserEvent(
+        type='user_recognized',
+        user_id=face_id,
+        score=score,
+        message=f'{face_id} を認識しました（score={score:.2f}）',
+    )
+
+
+def user_event_to_dict(event: UserEvent) -> Dict[str, Any]:
+    return event.model_dump()

--- a/shigure_api/shigure_api/feature_images.py
+++ b/shigure_api/shigure_api/feature_images.py
@@ -1,0 +1,46 @@
+"""Resolve feature_num to saved face crop images under face_models/."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Optional
+
+FACE_THUMBNAIL_SIZE = 128
+
+
+def feature_num_from_stem(user_id: str, file_stem: str) -> Optional[int]:
+    """Parse feature_num from e.g. user_new5_12628 (user_id + feature_num)."""
+    prefix = f'{user_id}_'
+    if not file_stem.startswith(prefix):
+        return None
+    suffix = file_stem[len(prefix) :]
+    if suffix.isdigit():
+        return int(suffix)
+    return None
+
+
+def find_face_image_path(
+    face_models_dir: Path, user_id: str, feature_num: int
+) -> Optional[Path]:
+    """Return user_*_{feature_num}.jpg under face_models/{user_id}/."""
+    if not face_models_dir.is_dir() or not user_id.startswith('user_'):
+        return None
+    path = face_models_dir / user_id / f'{user_id}_{feature_num}.jpg'
+    if not path.is_file():
+        return None
+    if feature_num_from_stem(user_id, path.stem) != feature_num:
+        return None
+    return path
+
+
+def load_face_thumbnail(path: Path, size: int = FACE_THUMBNAIL_SIZE) -> bytes:
+    """Resize face crop to a square JPEG thumbnail."""
+    from PIL import Image
+
+    with Image.open(path) as img:
+        rgb = img.convert('RGB')
+        rgb.thumbnail((size, size))
+        buf = io.BytesIO()
+        rgb.save(buf, format='JPEG', quality=85)
+        return buf.getvalue()

--- a/shigure_api/shigure_api/main.py
+++ b/shigure_api/shigure_api/main.py
@@ -1,0 +1,80 @@
+"""Entry point: ROS bridge thread + uvicorn."""
+
+from __future__ import annotations
+
+import argparse
+import threading
+from pathlib import Path
+
+import uvicorn
+
+from shigure_api.config import API_HOST, API_PORT, FACE_MODELS_DIR
+from shigure_api.ros_bridge import run_ros_bridge
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Shigure FastAPI + ROS event bridge')
+    parser.add_argument('--host', default=API_HOST, help='Bind host (use 0.0.0.0 for LAN)')
+    parser.add_argument('--port', type=int, default=API_PORT, help='HTTP/WebSocket port')
+    parser.add_argument(
+        '--face-models-dir',
+        default=str(FACE_MODELS_DIR),
+        help='Path to face_models directory',
+    )
+    args = parser.parse_args()
+
+    import shigure_api.config as config
+    from shigure_api.app import hub, init_pca_builder, pca_hub, tracking_debug_hub
+    from shigure_api.pca_plot import state_to_dict
+
+    config.FACE_MODELS_DIR = Path(args.face_models_dir).expanduser()
+    pca_builder = init_pca_builder(config.FACE_MODELS_DIR)
+
+    pca_hub.enqueue(state_to_dict(pca_builder.build_state()))
+
+    stop_event = threading.Event()
+
+    def on_event(event) -> None:
+        hub.enqueue(event)
+
+    def on_pca_payload(payload: dict) -> None:
+        pca_hub.enqueue(payload)
+
+    def on_tracking_debug(payload: dict) -> None:
+        tracking_debug_hub.enqueue(payload)
+
+    ros_thread = threading.Thread(
+        target=run_ros_bridge,
+        args=(on_event, stop_event),
+        kwargs={
+            'pca_builder': pca_builder,
+            'on_pca_payload': on_pca_payload,
+            'on_tracking_debug': on_tracking_debug,
+        },
+        name='shigure_ros_bridge',
+        daemon=True,
+    )
+    ros_thread.start()
+
+    print(
+        f'Shigure API: http://{args.host}:{args.port}  '
+        f'WebSocket: ws://{args.host}:{args.port}/ws/events  '
+        f'PCA plot: ws://{args.host}:{args.port}/ws/pca_plot  '
+        f'Tracking debug: ws://{args.host}:{args.port}/ws/tracking_debug  '
+        f'face_models={config.FACE_MODELS_DIR}'
+    )
+
+    try:
+        uvicorn.run(
+            'shigure_api.app:app',
+            host=args.host,
+            port=args.port,
+            log_level='info',
+        )
+    finally:
+        stop_event.set()
+        ros_thread.join(timeout=5.0)
+
+
+if __name__ == '__main__':
+    main()

--- a/shigure_api/shigure_api/pca_plot.py
+++ b/shigure_api/shigure_api/pca_plot.py
@@ -1,0 +1,434 @@
+"""PCA feature-map state for /ws/pca_plot WebSocket clients."""
+
+from __future__ import annotations
+
+import asyncio
+import pickle
+import queue
+import threading
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+
+from pydantic import BaseModel
+
+from shigure_api.feature_images import feature_num_from_stem
+
+Point2D = Tuple[float, float]
+
+
+class PcaPlotPoint(BaseModel):
+    x: float
+    y: float
+    feature_num: int
+
+
+class PreConfirmTrajectory(BaseModel):
+    people_id: str
+    face_id: Literal['unknown'] = 'unknown'
+    points: List[Tuple[float, float]]
+
+
+class PcaPlotState(BaseModel):
+    type: Literal['pca_plot_state'] = 'pca_plot_state'
+    timestamp: str
+    sequence: int
+    dictionary: Dict[str, List[PcaPlotPoint]]
+    labeled_new: Dict[str, List[PcaPlotPoint]]
+    unlabeled: List[PcaPlotPoint]
+    trajectories_pre_confirm: List[PreConfirmTrajectory]
+
+
+class PcaUnlabeledUpdate(BaseModel):
+    type: Literal['pca_unlabeled_update'] = 'pca_unlabeled_update'
+    timestamp: str
+    sequence: int
+    unlabeled: List[PcaPlotPoint]
+
+
+class PcaTrajectoryUpdate(BaseModel):
+    type: Literal['pca_trajectory_update'] = 'pca_trajectory_update'
+    timestamp: str
+    trajectories_pre_confirm: List[PreConfirmTrajectory]
+
+
+class PcaSegmentClosed(BaseModel):
+    type: Literal['pca_segment_closed'] = 'pca_segment_closed'
+    timestamp: str
+    people_id: str
+    user_id: str
+    promoted_feature_nums: List[int]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class PcaTransformer:
+    """512-dim embedding -> 2D using pca_model.pkl (same rules as feature_plot node)."""
+
+    def __init__(self, pca_path: Path) -> None:
+        self._pca_path = pca_path
+        self._pca = None
+        self._expected_dim: Optional[int] = None
+        self.reload(pca_path)
+
+    def reload(self, pca_path: Optional[Path] = None) -> None:
+        path = pca_path or self._pca_path
+        self._pca_path = path
+        self._pca = None
+        self._expected_dim = None
+        if path.is_file():
+            with open(path, 'rb') as f:
+                self._pca = pickle.load(f)
+            self._expected_dim = getattr(self._pca, 'n_features_in_', None)
+
+    def transform(self, feature: List[float]) -> Optional[Point2D]:
+        import numpy as np
+
+        feat = np.asarray(feature, dtype=np.float32).reshape(1, -1)
+        try:
+            if self._pca is not None and (
+                self._expected_dim is None or feat.shape[1] == self._expected_dim
+            ):
+                pt = self._pca.transform(feat)[0]
+            else:
+                import faiss
+
+                faiss.normalize_L2(feat)
+                pt = feat[0, :2]
+            return float(pt[0]), float(pt[1])
+        except Exception:
+            return None
+
+
+def load_dictionary_points(
+    face_models_dir: Path, transformer: PcaTransformer
+) -> Dict[str, List[PcaPlotPoint]]:
+    out: Dict[str, List[PcaPlotPoint]] = {}
+    if not face_models_dir.is_dir():
+        return out
+    for user_dir in sorted(face_models_dir.glob('user_*')):
+        if not user_dir.is_dir():
+            continue
+        uid = user_dir.name
+        points: List[PcaPlotPoint] = []
+        for npy_path in sorted(user_dir.glob('*.npy')):
+            import numpy as np
+
+            fn = feature_num_from_stem(uid, npy_path.stem)
+            if fn is None:
+                continue
+            raw = np.squeeze(np.load(npy_path)).astype(np.float32).reshape(-1).tolist()
+            pt = transformer.transform(raw)
+            if pt is not None:
+                points.append(PcaPlotPoint(x=pt[0], y=pt[1], feature_num=fn))
+        if points:
+            out[uid] = points
+    return out
+
+
+def should_promote_face_for_user(face_id: str, confirmed_user_id: str) -> bool:
+    """Promote PCA points only for the face_id bucket that matches confirmation."""
+    if face_id.endswith('@profile'):
+        return False
+    if face_id == confirmed_user_id:
+        return True
+    # New user_new* registration uses the unknown bucket at confirm time.
+    if face_id == 'unknown' and confirmed_user_id.startswith('user_new'):
+        return True
+    return False
+
+
+class PcaPlotStateBuilder:
+    """Thread-safe PCA plot state (mirrors feature_plot logic, pre_confirm trajectories only)."""
+
+    def __init__(
+        self,
+        face_models_dir: Path,
+        pca_path: Path,
+        *,
+        redraw_every: int = 5,
+        trajectory_max_points: int = 50,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._redraw_every = max(1, redraw_every)
+        self._trajectory_max_points = max(2, trajectory_max_points)
+        self._sequence = 0
+        self._feature_counter = 0
+        self._face_models_dir = face_models_dir
+        self._pca_path = pca_path
+
+        self._transformer = PcaTransformer(pca_path)
+        self._dictionary: Dict[str, List[PcaPlotPoint]] = load_dictionary_points(
+            face_models_dir, self._transformer
+        )
+        self._labeled_new: Dict[str, List[PcaPlotPoint]] = defaultdict(list)
+        self._unlabeled: Dict[int, Point2D] = {}
+        self._feature_map: Dict[int, Point2D] = {}
+        self._raw_features: Dict[int, List[float]] = {}
+        self._confirmed_people: Dict[str, str] = {}
+        self._promoted_feature_nums: Set[int] = set()
+        self._latest_history = None
+        self._known_user_count = sum(
+            1 for p in face_models_dir.glob('user_*') if p.is_dir()
+        ) if face_models_dir.is_dir() else 0
+
+    def on_feature_info(self, feature_num: int, feature: List[float]) -> bool:
+        """Returns True if clients should receive an update (redraw_every)."""
+        pt = self._transformer.transform(feature)
+        if pt is None:
+            return False
+        with self._lock:
+            self._raw_features[feature_num] = list(feature)
+            self._feature_map[feature_num] = pt
+            if feature_num not in self._promoted_feature_nums:
+                self._unlabeled[feature_num] = pt
+            self._feature_counter += 1
+            return self._feature_counter % self._redraw_every == 0
+
+    def rebuild_pca_from_disk(self, registered_user_id: Optional[str] = None) -> bool:
+        """Rebuild pca_model.pkl, reload coordinates, and refresh dictionary from disk."""
+        from shigure_core.util.pca_model import build_pca_model, count_user_dirs
+
+        face_models_dir = self._face_models_dir
+        user_count = count_user_dirs(face_models_dir)
+        if registered_user_id is None and user_count <= self._known_user_count:
+            return False
+
+        result = build_pca_model(face_models_dir, self._pca_path)
+        if not result.success:
+            return False
+
+        with self._lock:
+            self._known_user_count = user_count
+            self._transformer.reload(self._pca_path)
+            self._dictionary = load_dictionary_points(face_models_dir, self._transformer)
+
+            for fn, raw in list(self._raw_features.items()):
+                pt = self._transformer.transform(raw)
+                if pt is None:
+                    continue
+                self._feature_map[fn] = pt
+                if fn in self._unlabeled:
+                    self._unlabeled[fn] = pt
+
+            for uid, points in list(self._labeled_new.items()):
+                rebuilt: List[PcaPlotPoint] = []
+                for point in points:
+                    raw = self._raw_features.get(point.feature_num)
+                    if raw is None:
+                        rebuilt.append(point)
+                        continue
+                    pt = self._transformer.transform(raw)
+                    if pt is not None:
+                        rebuilt.append(
+                            PcaPlotPoint(
+                                x=pt[0], y=pt[1], feature_num=point.feature_num
+                            )
+                        )
+                if rebuilt:
+                    self._labeled_new[uid] = rebuilt
+
+            if registered_user_id:
+                # Disk dictionary now includes the new user; avoid duplicate layers.
+                self._labeled_new.pop(registered_user_id, None)
+
+        return True
+
+    def reload_dictionary_from_disk(self) -> None:
+        """Reload dictionary points from face_models without rebuilding PCA."""
+        with self._lock:
+            self._dictionary = load_dictionary_points(
+                self._face_models_dir, self._transformer
+            )
+
+    def clear_labeled_new(self, user_id: str) -> None:
+        with self._lock:
+            self._labeled_new.pop(user_id, None)
+
+    def on_recognition_history(self, msg) -> None:
+        with self._lock:
+            self._latest_history = msg
+
+    def on_dictionary_update(self, people_id: str, name: str) -> Optional[PcaSegmentClosed]:
+        if not name or name == 'none':
+            return None
+        promoted: List[int] = []
+        with self._lock:
+            self._confirmed_people[people_id] = name
+            if self._latest_history is not None:
+                for user in self._latest_history.users:
+                    if user.people_id != people_id:
+                        continue
+                    for face in user.face_info:
+                        if not should_promote_face_for_user(face.id, name):
+                            continue
+                        for fn in face.features_num:
+                            fn_int = int(fn)
+                            promoted.append(fn_int)
+                            pt = self._feature_map.get(fn_int)
+                            if pt is not None:
+                                self._labeled_new[name].append(
+                                    PcaPlotPoint(x=pt[0], y=pt[1], feature_num=fn_int)
+                                )
+                            self._unlabeled.pop(fn_int, None)
+                            self._promoted_feature_nums.add(fn_int)
+            promoted = sorted(set(promoted))
+        return PcaSegmentClosed(
+            timestamp=_now_iso(),
+            people_id=people_id,
+            user_id=name,
+            promoted_feature_nums=promoted,
+        )
+
+    def build_unlabeled_update(self) -> PcaUnlabeledUpdate:
+        with self._lock:
+            self._sequence += 1
+            unlabeled = [
+                PcaPlotPoint(feature_num=fn, x=pt[0], y=pt[1])
+                for fn, pt in sorted(self._unlabeled.items())
+            ]
+            return PcaUnlabeledUpdate(
+                timestamp=_now_iso(),
+                sequence=self._sequence,
+                unlabeled=unlabeled,
+            )
+
+    def build_trajectory_update(self) -> PcaTrajectoryUpdate:
+        with self._lock:
+            return PcaTrajectoryUpdate(
+                timestamp=_now_iso(),
+                trajectories_pre_confirm=self._build_trajectories_pre_confirm(),
+            )
+
+    def build_state(self) -> PcaPlotState:
+        with self._lock:
+            self._sequence += 1
+            trajectories = self._build_trajectories_pre_confirm()
+            unlabeled = [
+                PcaPlotPoint(feature_num=fn, x=pt[0], y=pt[1])
+                for fn, pt in sorted(self._unlabeled.items())
+            ]
+            return PcaPlotState(
+                timestamp=_now_iso(),
+                sequence=self._sequence,
+                dictionary={k: list(v) for k, v in self._dictionary.items()},
+                labeled_new={k: list(v) for k, v in self._labeled_new.items()},
+                unlabeled=unlabeled,
+                trajectories_pre_confirm=trajectories,
+            )
+
+    def _build_trajectories_pre_confirm(self) -> List[PreConfirmTrajectory]:
+        if self._latest_history is None:
+            return []
+        out: List[PreConfirmTrajectory] = []
+        for user in self._latest_history.users:
+            people_id = user.people_id
+            if people_id in self._confirmed_people:
+                continue
+            feature_nums: List[int] = []
+            for face in user.face_info:
+                if face.id.endswith('@profile'):
+                    continue
+                if face.id != 'unknown':
+                    continue
+                feature_nums.extend(int(fn) for fn in face.features_num)
+            feature_nums = sorted(set(feature_nums))
+            points: List[Point2D] = []
+            for fn in feature_nums:
+                pt = self._feature_map.get(fn)
+                if pt is not None:
+                    points.append(pt)
+            if len(points) > self._trajectory_max_points:
+                points = points[-self._trajectory_max_points :]
+            if len(points) >= 2:
+                out.append(
+                    PreConfirmTrajectory(
+                        people_id=people_id,
+                        points=points,
+                    )
+                )
+        return out
+
+
+class PcaPlotHub:
+    """Broadcast PCA plot JSON to WebSocket clients."""
+
+    def __init__(self) -> None:
+        self._clients: Set[Any] = set()
+        self._lock = asyncio.Lock()
+        self._thread_queue: queue.Queue[Dict[str, Any]] = queue.Queue()
+        self._latest_state: Optional[Dict[str, Any]] = None
+
+    async def start(self) -> None:
+        asyncio.create_task(self._broadcast_loop())
+
+    def enqueue(self, payload: Dict[str, Any]) -> None:
+        self._thread_queue.put_nowait(payload)
+
+    async def _broadcast_loop(self) -> None:
+        while True:
+            payload = await asyncio.to_thread(self._thread_queue.get)
+            if payload.get('type') == 'pca_plot_state':
+                self._latest_state = payload
+            elif (
+                payload.get('type') == 'pca_unlabeled_update'
+                and self._latest_state is not None
+            ):
+                self._latest_state = {
+                    **self._latest_state,
+                    'unlabeled': payload.get('unlabeled', []),
+                    'sequence': payload.get('sequence', self._latest_state.get('sequence', 0)),
+                    'timestamp': payload.get(
+                        'timestamp', self._latest_state.get('timestamp', '')
+                    ),
+                }
+            elif (
+                payload.get('type') == 'pca_trajectory_update'
+                and self._latest_state is not None
+            ):
+                self._latest_state = {
+                    **self._latest_state,
+                    'trajectories_pre_confirm': payload.get(
+                        'trajectories_pre_confirm', []
+                    ),
+                    'timestamp': payload.get('timestamp', self._latest_state['timestamp']),
+                }
+            async with self._lock:
+                dead = []
+                for ws in self._clients:
+                    try:
+                        await ws.send_json(payload)
+                    except Exception:
+                        dead.append(ws)
+                for ws in dead:
+                    self._clients.discard(ws)
+
+    async def connect(self, websocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._clients.add(websocket)
+        if self._latest_state is not None:
+            await websocket.send_json(self._latest_state)
+
+    async def disconnect(self, websocket) -> None:
+        async with self._lock:
+            self._clients.discard(websocket)
+
+
+def state_to_dict(state: PcaPlotState) -> Dict[str, Any]:
+    return state.model_dump()
+
+
+def unlabeled_update_to_dict(msg: PcaUnlabeledUpdate) -> Dict[str, Any]:
+    return msg.model_dump()
+
+
+def trajectory_update_to_dict(msg: PcaTrajectoryUpdate) -> Dict[str, Any]:
+    return msg.model_dump()
+
+
+def segment_closed_to_dict(msg: PcaSegmentClosed) -> Dict[str, Any]:
+    return msg.model_dump()

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -1,0 +1,224 @@
+"""ROS2 subscriber that forwards recognition events to the FastAPI layer."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Dict, Optional
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from shigure_core_msgs.msg import (
+    DebugImage,
+    DictionaryUpdate,
+    FaceRecognitionResult,
+    FeatureInfo,
+    RecognitionHistory,
+)
+
+from shigure_api.config import (
+    DICTIONARY_UPDATE_TOPIC,
+    FACE_RECOGNITION_TOPIC,
+    FEATURE_INFO_TOPIC,
+    PCA_REBUILD_ON_NEW_USER,
+    RECOGNITION_DEBOUNCE_SEC,
+    RECOGNITION_HISTORY_TOPIC,
+    RECOGNITION_SCORE_THRESHOLD,
+    TRACKING_DEBUG_IMAGE_TOPIC,
+)
+from shigure_api.events import event_from_dictionary_update, event_from_face_recognition
+from shigure_api.pca_plot import (
+    PcaPlotStateBuilder,
+    segment_closed_to_dict,
+    state_to_dict,
+    unlabeled_update_to_dict,
+)
+from shigure_api.tracking_debug import debug_image_msg_to_payload
+
+
+class RosEventBridge(Node):
+    """Subscribe to Shigure topics and invoke callbacks for events and PCA plot."""
+
+    def __init__(
+        self,
+        on_event: Callable,
+        pca_builder: Optional[PcaPlotStateBuilder] = None,
+        on_pca_payload: Optional[Callable[[dict], None]] = None,
+        on_tracking_debug: Optional[Callable[[dict], None]] = None,
+    ):
+        super().__init__('shigure_api_bridge')
+        self._on_event = on_event
+        self._pca_builder = pca_builder
+        self._on_pca_payload = on_pca_payload
+        self._on_tracking_debug = on_tracking_debug
+        self._recognition_last_sent: Dict[str, float] = {}
+        self._lock = threading.Lock()
+
+        shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
+        self.create_subscription(
+            DictionaryUpdate,
+            DICTIONARY_UPDATE_TOPIC,
+            self._on_dictionary_update,
+            10,
+        )
+        self.create_subscription(
+            FaceRecognitionResult,
+            FACE_RECOGNITION_TOPIC,
+            self._on_face_recognition,
+            shigure_qos,
+        )
+        if self._pca_builder is not None and self._on_pca_payload is not None:
+            self.create_subscription(
+                FeatureInfo,
+                FEATURE_INFO_TOPIC,
+                self._on_feature_info,
+                shigure_qos,
+            )
+            self.create_subscription(
+                RecognitionHistory,
+                RECOGNITION_HISTORY_TOPIC,
+                self._on_recognition_history,
+                10,
+            )
+            self.get_logger().info(
+                f'PCA plot listening on {FEATURE_INFO_TOPIC} and {RECOGNITION_HISTORY_TOPIC}'
+            )
+            self._publish_pca_state()
+
+        if self._on_tracking_debug is not None:
+            self.create_subscription(
+                DebugImage,
+                TRACKING_DEBUG_IMAGE_TOPIC,
+                self._on_tracking_debug_image,
+                shigure_qos,
+            )
+            self.get_logger().info(
+                f'Tracking debug images on {TRACKING_DEBUG_IMAGE_TOPIC}'
+            )
+
+        self.get_logger().info(
+            f'Listening on {DICTIONARY_UPDATE_TOPIC} and {FACE_RECOGNITION_TOPIC}'
+        )
+
+    def _emit(self, event) -> None:
+        try:
+            self._on_event(event)
+        except Exception as exc:
+            self.get_logger().error(f'Failed to emit event: {exc}')
+
+    def _emit_pca(self, payload: dict) -> None:
+        if self._on_pca_payload is None:
+            return
+        try:
+            self._on_pca_payload(payload)
+        except Exception as exc:
+            self.get_logger().error(f'Failed to emit PCA payload: {exc}')
+
+    def _emit_tracking_debug(self, payload: dict) -> None:
+        if self._on_tracking_debug is None:
+            return
+        try:
+            self._on_tracking_debug(payload)
+        except Exception as exc:
+            self.get_logger().error(f'Failed to emit tracking debug image: {exc}')
+
+    def _on_tracking_debug_image(self, msg: DebugImage) -> None:
+        self._emit_tracking_debug(debug_image_msg_to_payload(msg))
+
+    def _publish_pca_state(self) -> None:
+        if self._pca_builder is None:
+            return
+        self._emit_pca(state_to_dict(self._pca_builder.build_state()))
+
+    def _publish_unlabeled_update(self) -> None:
+        if self._pca_builder is None:
+            return
+        self._emit_pca(unlabeled_update_to_dict(self._pca_builder.build_unlabeled_update()))
+
+    def _on_dictionary_update(self, msg: DictionaryUpdate) -> None:
+        event = event_from_dictionary_update(msg.people_id, msg.name)
+        if event is not None:
+            self.get_logger().info(f'Dictionary update: {event.type} user_id={event.user_id}')
+            self._emit(event)
+
+        if self._pca_builder is not None:
+            closed = self._pca_builder.on_dictionary_update(msg.people_id, msg.name)
+            if closed is not None:
+                self._emit_pca(segment_closed_to_dict(closed))
+
+            if event is not None and event.type == 'user_registered':
+                if PCA_REBUILD_ON_NEW_USER:
+                    rebuilt = self._pca_builder.rebuild_pca_from_disk(
+                        registered_user_id=event.user_id
+                    )
+                    if rebuilt:
+                        self.get_logger().info(
+                            f'PCA model rebuilt after new user: {event.user_id}'
+                        )
+                self._publish_pca_state()
+            elif event is not None and event.type == 'user_confirmed':
+                self._pca_builder.reload_dictionary_from_disk()
+                self._pca_builder.clear_labeled_new(event.user_id)
+                self._publish_pca_state()
+
+    def _on_face_recognition(self, msg: FaceRecognitionResult) -> None:
+        now = time.monotonic()
+        for face in msg.faces:
+            if face.score < RECOGNITION_SCORE_THRESHOLD:
+                continue
+            event = event_from_face_recognition(face.id, float(face.score))
+            if event is None:
+                continue
+            key = event.user_id
+            with self._lock:
+                last = self._recognition_last_sent.get(key, 0.0)
+                if now - last < RECOGNITION_DEBOUNCE_SEC:
+                    continue
+                self._recognition_last_sent[key] = now
+            self._emit(event)
+
+    def _on_feature_info(self, msg: FeatureInfo) -> None:
+        if self._pca_builder is None:
+            return
+        should_push = self._pca_builder.on_feature_info(
+            int(msg.feature_num),
+            list(msg.feature),
+        )
+        if should_push:
+            self._publish_unlabeled_update()
+
+    def _on_recognition_history(self, msg: RecognitionHistory) -> None:
+        if self._pca_builder is None:
+            return
+        self._pca_builder.on_recognition_history(msg)
+
+    def clear_debounce(self, user_id: Optional[str] = None) -> None:
+        with self._lock:
+            if user_id is None:
+                self._recognition_last_sent.clear()
+            else:
+                self._recognition_last_sent.pop(user_id, None)
+
+
+def run_ros_bridge(
+    on_event: Callable,
+    stop_event: threading.Event,
+    *,
+    pca_builder: Optional[PcaPlotStateBuilder] = None,
+    on_pca_payload: Optional[Callable[[dict], None]] = None,
+    on_tracking_debug: Optional[Callable[[dict], None]] = None,
+) -> None:
+    rclpy.init()
+    node = RosEventBridge(
+        on_event,
+        pca_builder=pca_builder,
+        on_pca_payload=on_pca_payload,
+        on_tracking_debug=on_tracking_debug,
+    )
+    try:
+        while rclpy.ok() and not stop_event.is_set():
+            rclpy.spin_once(node, timeout_sec=0.1)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/shigure_api/shigure_api/tracking_debug.py
+++ b/shigure_api/shigure_api/tracking_debug.py
@@ -1,0 +1,83 @@
+"""Tracking debug overlay images for WebSocket clients."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import queue
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Set
+
+from pydantic import BaseModel
+
+
+class TrackingDebugImage(BaseModel):
+    type: str = 'tracking_debug_image'
+    timestamp: str
+    frame: int
+    format: str = 'jpeg'
+    image_base64: str
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def debug_image_msg_to_payload(msg) -> Dict[str, Any]:
+    """ROS DebugImage -> JSON-serializable dict (JPEG base64)."""
+    frame = 0
+    if msg.header.frame_id:
+        try:
+            frame = int(msg.header.frame_id)
+        except ValueError:
+            frame = 0
+    image_format = msg.format or 'jpeg'
+    encoded = base64.b64encode(bytes(msg.data)).decode('ascii')
+    return TrackingDebugImage(
+        timestamp=_now_iso(),
+        frame=frame,
+        format=image_format,
+        image_base64=encoded,
+    ).model_dump()
+
+
+class TrackingDebugHub:
+    """Broadcast tracking debug images to WebSocket clients."""
+
+    def __init__(self) -> None:
+        self._clients: Set[Any] = set()
+        self._lock = asyncio.Lock()
+        self._thread_queue: queue.Queue[Dict[str, Any]] = queue.Queue()
+        self._latest_payload: Optional[Dict[str, Any]] = None
+
+    async def start(self) -> None:
+        asyncio.create_task(self._broadcast_loop())
+
+    def enqueue(self, payload: Dict[str, Any]) -> None:
+        self._thread_queue.put_nowait(payload)
+
+    async def _broadcast_loop(self) -> None:
+        while True:
+            payload = await asyncio.to_thread(self._thread_queue.get)
+            if payload.get('type') == 'tracking_debug_image':
+                self._latest_payload = payload
+            async with self._lock:
+                dead = []
+                for ws in self._clients:
+                    try:
+                        await ws.send_json(payload)
+                    except Exception:
+                        dead.append(ws)
+                for ws in dead:
+                    self._clients.discard(ws)
+
+    async def connect(self, websocket) -> None:
+        await websocket.accept()
+        async with self._lock:
+            self._clients.add(websocket)
+        if self._latest_payload is not None:
+            await websocket.send_json(self._latest_payload)
+
+    async def disconnect(self, websocket) -> None:
+        async with self._lock:
+            self._clients.discard(websocket)

--- a/shigure_core/setup.py
+++ b/shigure_core/setup.py
@@ -47,6 +47,9 @@ setup(
             'caputure_flow = shigure_core.nodes.capture_ros:main',
             'pointer_transform_listener = shigure_core.nodes.pointer_transform_listener:main',
             'node_raycast_hit_detection = shigure_core.nodes.node_raycast_hit_detection:main',
+            'face_models = shigure_core.nodes.node_face_models:main',
+            'people_recognition = shigure_core.nodes.node_people_recognition:main',
+            'rebuild_pca_model = shigure_core.util.pca_model:main',
         ],
     },
 )

--- a/shigure_core/shigure_core/launch/shigure_core_launch.py
+++ b/shigure_core/shigure_core/launch/shigure_core_launch.py
@@ -1,14 +1,56 @@
+"""YOLO11 + 顔認識パイプライン（既定 launch）。
+
+launch 引数:
+  debug_mode:=true/false    全ノードの is_debug_mode を制御（既定 false）。
+                            true で各ノードの cv2 デバッグ窓を表示し、
+                            people_recognition は自動登録ユーザーの .npy/.jpg をディスク保存する。
+  save_image:=true/false    true で people_tracking が追跡デバッグ画像を
+                            /shigure/tracking_debug_image へ配信・保存し、Web表示(shigure_api)を起動（既定 false）。
+  enable_profile:=true/false true で横顔プロフィール特徴を /profile_feature_add に配信（既定 false）。
+
+例:
+  ros2 launch shigure_core shigure_core_launch.py
+  ros2 launch shigure_core shigure_core_launch.py debug_mode:=true save_image:=true
+"""
+
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
 
 def generate_launch_description():
+    debug_mode = LaunchConfiguration('debug_mode')
+    save_image = LaunchConfiguration('save_image')
+    enable_profile = LaunchConfiguration('enable_profile')
+
+    # 全ノード共通で使う is_debug_mode パラメータ（launch 引数 debug_mode で制御）
+    is_debug = {"is_debug_mode": ParameterValue(debug_mode, value_type=bool)}
+
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'debug_mode',
+            default_value='false',
+            description='true のとき全ノードの is_debug_mode を有効化（cv2デバッグ窓表示・顔データのディスク保存）。',
+        ),
+        DeclareLaunchArgument(
+            'save_image',
+            default_value='false',
+            description='true のとき追跡デバッグ画像を保存・配信し、Web表示(shigure_api)を起動する。',
+        ),
+        DeclareLaunchArgument(
+            'enable_profile',
+            default_value='false',
+            description='true のとき横顔プロフィール特徴を /profile_feature_add に配信する（横顔学習）。',
+        ),
         Node(
             package="shigure_core",
             executable="yolox_object_detection",
             prefix="gnome-terminal --tab -t 'yolox_object_detection' --",
             parameters=[
-                {"is_debug_mode": True},
+                is_debug,
             ],
         ),
         Node(
@@ -16,7 +58,7 @@ def generate_launch_description():
             executable="object_tracking",
             prefix="gnome-terminal --tab -t 'object_tracking' --",
             parameters=[
-                {"is_debug_mode": True},
+                is_debug,
             ],
         ),
         Node(
@@ -24,8 +66,20 @@ def generate_launch_description():
             executable="people_tracking",
             prefix="gnome-terminal --tab -t 'people_tracking' --",
             parameters=[
-                {"is_debug_mode": False},
-                {"focal_length":1.0},
+                is_debug,
+                {"focal_length": 1.0},
+                {"save_image": ParameterValue(save_image, value_type=bool)},
+                {"enable_profile_insightface": ParameterValue(enable_profile, value_type=bool)},
+            ],
+        ),
+        # 顔認識（/face_recognition/results, /feature_info, /dictionary_update を配信）
+        # is_debug_mode=true のとき自動登録ユーザーの特徴/画像をディスク保存する。
+        Node(
+            package="shigure_core",
+            executable="people_recognition",
+            prefix="gnome-terminal --tab -t 'people_recognition' --",
+            parameters=[
+                is_debug,
             ],
         ),
         Node(
@@ -33,7 +87,14 @@ def generate_launch_description():
             executable="contact_detection",
             prefix="gnome-terminal --tab -t 'contact_detection' --",
             parameters=[
-                {"is_debug_mode": True},
+                is_debug,
             ],
-        )
-            ])
+        ),
+        # Web API（save_image:=true のときのみ起動）
+        Node(
+            package="shigure_api",
+            executable="shigure_api",
+            prefix="gnome-terminal --tab -t 'shigure_api' --",
+            condition=IfCondition(save_image),
+        ),
+    ])

--- a/shigure_core/shigure_core/nodes/node_face_models.py
+++ b/shigure_core/shigure_core/nodes/node_face_models.py
@@ -1,0 +1,130 @@
+import os
+import glob
+import cv2
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import CompressedImage
+import message_filters
+
+from shigure_core.nodes.profile_insightface import ProfileInsightFace
+
+# 顔特徴(.npy)と顔画像(.jpg)の保存先。people_recognition / shigure_api が読む辞書と同じ場所。
+# SHIGURE_FACE_MODELS_DIR 環境変数があれば最優先。無ければ固定の永続パス ~/.shigure/face_models。
+# （env 未設定でも全ノード・shigure_api が同じ場所を見る／ビルドで消えない／別PCでも同挙動）
+_env_face_models_dir = os.environ.get('SHIGURE_FACE_MODELS_DIR')
+FACE_MODELS_DIR = (
+    os.path.expanduser(_env_face_models_dir)
+    if _env_face_models_dir
+    else os.path.expanduser('~/.shigure/face_models')
+)
+
+
+class FaceCaptureNode(Node):
+    def __init__(self):
+        super().__init__('face_capture_node')
+
+        # QoS Settings
+        qos_profile = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
+
+        # サブスクライバー設定
+        self.image_sub = message_filters.Subscriber(self, CompressedImage, '/rs/color/compressed', qos_profile=qos_profile)
+        self.sync = message_filters.TimeSynchronizer([self.image_sub], 10)
+        self.sync.registerCallback(self.image_callback)
+
+        # ユーザーに名前を入力させる（辞書のフォルダ名＝表示名になるため user_ 規約に従う）
+        self.name = input("ユーザー名を入力してください: ")
+
+        dir = "user_" + self.name
+
+        # 保存ディレクトリ設定
+        self.save_directory = os.path.join(FACE_MODELS_DIR, dir)
+        os.makedirs(self.save_directory, exist_ok=True)
+        self.get_logger().info(f"保存先: {self.save_directory}")
+
+        # モデルの読み込み
+        self.insightface = ProfileInsightFace()
+        if not self.insightface.available:
+            raise RuntimeError("insightface is not installed")
+
+        # 撮影枚数のカウント
+        self.feature_count = len(glob.glob(os.path.join(self.save_directory, "*.npy")))
+        self.max_images = 100
+
+    def image_callback(self, compressed_image):
+        # 最大撮影枚数に達した場合、処理を終了する
+        if self.feature_count >= self.max_images:
+            self.get_logger().info(f"Reached {self.max_images} images, stopping the node.")
+            rclpy.shutdown()
+            return
+
+        # 画像データを取得
+        color_img = self.compressed_imgmsg_to_cv2(compressed_image)
+
+        # 画像のリサイズ
+        resized_image = cv2.resize(color_img, (1280, 720))
+
+        # 顔検出
+        detected_faces = self.insightface.detect_faces(resized_image)
+
+        # 検出された顔がある場合
+        if detected_faces is not None:
+            for iface_face in detected_faces:
+                if not iface_face.is_frontal:
+                    continue
+
+                # 顔の四角形の位置を取得
+                x, y, w, h = iface_face.bbox
+                print(x, y, w, h)
+
+                # 画像の幅と高さ
+                img_height, img_width = resized_image.shape[:2]
+
+                # 顔の座標が画像範囲外にある場合、スキップ
+                if x < 20 or y < 20 or x + w > img_width - 20 or y + h > img_height - 20:
+                    print("Detected face is partially outside the screen. Skipping this face.")
+                    continue  # 画面外の顔を無視
+
+                # 顔の領域をクロップして特徴を抽出
+                face_crop = resized_image[y:y + h, x:x + w]
+
+                # 顔画像と特徴ベクトルを保存
+                self.save_face_data(face_crop, iface_face.embedding)
+
+    def save_face_data(self, face_image, feature_vector):
+        # 保存するファイル名を設定
+        self.feature_count += 1
+        img_filename = os.path.join(self.save_directory, f"{self.name}{self.feature_count}.jpg")
+        npy_filename = os.path.join(self.save_directory, f"{self.name}{self.feature_count}.npy")
+
+        # 顔画像を保存 (JPEG)
+        cv2.imwrite(img_filename, face_image)
+
+        # 特徴ベクトルを保存 (NumPy)
+        np.save(npy_filename, feature_vector)
+
+        self.get_logger().info(f"Saved face image as {img_filename} and feature vector as {npy_filename}")
+
+    def compressed_imgmsg_to_cv2(self, compressed_img_msg):
+        # ROS2のCompressedImageメッセージをOpenCVの画像形式に変換する
+        np_arr = np.frombuffer(compressed_img_msg.data, np.uint8)
+        image_np = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+        return image_np
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    face_capture_node = FaceCaptureNode()
+
+    try:
+        rclpy.spin(face_capture_node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        face_capture_node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/shigure_core/shigure_core/nodes/node_people_recognition.py
+++ b/shigure_core/shigure_core/nodes/node_people_recognition.py
@@ -1,0 +1,706 @@
+import cv2
+import message_filters
+import numpy as np
+import rclpy
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from sensor_msgs.msg import CompressedImage
+from shigure_core_msgs.msg import FaceRecognitionResult, FaceInfo, RecognitionHistory, DictionaryUpdate, FeatureInfo, ProfileFeatureAdd
+
+import os
+import glob
+import time
+from pathlib import Path
+from PIL import Image
+
+from shigure_core.nodes.node_image_preview import ImagePreviewNode
+from shigure_core.nodes.profile_insightface import ProfileInsightFace, InsightFaceResult
+from shigure_core.util.pca_model import build_pca_model
+
+from sklearn.semi_supervised import LabelPropagation
+from collections import Counter
+
+from std_msgs.msg import Header
+import faiss
+
+# COSINE_THRESHOLD = 0.363
+COSINE_THRESHOLD = 0.4
+PROFILE_COSINE_THRESHOLD = 0.4
+NORML2_THRESHOLD = 1.128
+LP_CONFIDENCE_THRESHOLD = 0.7
+FAISS_FALLBACK_MIN_VOTE_RATIO = 0.5
+MIN_DET_SCORE = 0.8
+# 新規ユーザーとして辞書登録する最低特徴数（この数を超えたら dictionary_renew で登録判定）。
+MIN_FEATURES_FOR_NEW_USER = 20
+
+# 顔辞書(face_models)。node_face_models の登録先・shigure_api の参照先と一致させること。
+# SHIGURE_FACE_MODELS_DIR 環境変数があれば最優先。無ければ固定の永続パス ~/.shigure/face_models。
+_env_face_models_dir = os.environ.get('SHIGURE_FACE_MODELS_DIR')
+DIRECTORY = (
+    os.path.expanduser(_env_face_models_dir)
+    if _env_face_models_dir
+    else os.path.expanduser('~/.shigure/face_models')
+)
+
+class PeopleRecognitionNode(ImagePreviewNode):
+
+    def __init__(self):
+        super().__init__('people_recognition_node')
+
+        self.recognition_results = {}
+        self.feature_num = 1
+        self.last_renew_time = time.time()
+
+        self.all_features = {}
+        self.all_images = {}
+        self.last_recognition_history = None  # 最後に受信したrecognition_history
+
+        # QoS Settings
+        shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
+
+        # サブスクライバーとパブリッシャーの設定
+        self.image_sub = message_filters.Subscriber(self, CompressedImage, '/rs/color/compressed', qos_profile=shigure_qos)
+        self.sync = message_filters.TimeSynchronizer([self.image_sub], 10)
+        self.sync.registerCallback(self.callback)
+
+        self.recognition_history_sub = self.create_subscription(RecognitionHistory, '/shigure/recognition_history', self.callback_recognition_history, 10)
+        self.profile_feature_add_sub = self.create_subscription(
+            ProfileFeatureAdd, '/profile_feature_add', self.callback_profile_feature_add, 10
+        )
+        
+        self.publisher = self.create_publisher(FaceRecognitionResult, '/face_recognition/results', 10)
+        self.update_pub = self.create_publisher(DictionaryUpdate, '/dictionary_update', 10)
+        # 描画ノード (node_feature_plot) 用に特徴ベクトルを配信
+        self.feature_pub = self.create_publisher(FeatureInfo, '/feature_info', 10)
+
+        # モデルロード #############################################################
+        self.insightface = ProfileInsightFace()
+        if not self.insightface.available:
+            raise RuntimeError("insightface is not installed")
+
+        # 特徴を読み込む
+        self.dictionary = {}
+        user_dirs = glob.glob(os.path.join(DIRECTORY, "user_*"))
+        for user_dir in user_dirs:
+            user_id = os.path.basename(user_dir)
+            features = []
+            for file in glob.glob(os.path.join(user_dir, "*.npy")):
+                feature = np.load(file)
+                features.append(np.squeeze(feature)) # 事前に形を整える
+            if features:
+                self.dictionary[user_id] = features
+
+        self.profile_dictionary = {}
+        for user_dir in user_dirs:
+            user_id = os.path.basename(user_dir)
+            profile_dir = os.path.join(user_dir, 'profile')
+            features = []
+            if os.path.isdir(profile_dir):
+                for file in glob.glob(os.path.join(profile_dir, '*.npy')):
+                    feature = np.load(file)
+                    features.append(np.squeeze(feature).astype('float32'))
+            if features:
+                self.profile_dictionary[user_id] = features
+
+        # people_idとuser_idの対応付け用辞書
+        self.user_id_map = {}
+
+    def rebuild_pca_model_on_disk(self) -> None:
+        """Rebuild pca_model.pkl from face_models (after new user saved to disk)."""
+        if not self.is_debug_mode:
+            return
+        result = build_pca_model(Path(DIRECTORY), Path(DIRECTORY) / 'pca_model.pkl')
+        if result.success:
+            self.get_logger().info(f'[PCA] {result.message}')
+        else:
+            self.get_logger().warn(f'[PCA] rebuild skipped: {result.message}')
+
+    def _ensure_profile_user_entry(self, user_id):
+        if user_id not in self.profile_dictionary:
+            self.profile_dictionary[user_id] = []
+
+    def add_profile_feature(self, user_name, embedding, face_image=None):
+        """横顔特徴を profile_dictionary とディスクに追加（照合辞書の正）。"""
+        if not user_name or not user_name.startswith('user'):
+            return
+
+        embedding = np.asarray(embedding, dtype=np.float32).reshape(-1)
+        self._ensure_profile_user_entry(user_name)
+        self.profile_dictionary[user_name].append(embedding)
+        self.get_logger().info(
+            f'Added profile feature: user_id={user_name}, '
+            f'total={len(self.profile_dictionary[user_name])}'
+        )
+
+        if not self.is_debug_mode:
+            return
+
+        profile_dir = os.path.join(DIRECTORY, user_name, 'profile')
+        os.makedirs(profile_dir, exist_ok=True)
+        existing = glob.glob(os.path.join(profile_dir, '*.npy'))
+        idx = len(existing) + 1
+        feature_path = os.path.join(profile_dir, f'{user_name}_profile_{idx}.npy')
+        np.save(feature_path, embedding)
+        self.get_logger().info(f'Saved profile feature: {feature_path}')
+
+        if face_image is not None:
+            image_path = os.path.join(profile_dir, f'{user_name}_profile_{idx}.jpg')
+            cv2.imwrite(image_path, face_image)
+            self.get_logger().info(f'Saved profile image: {image_path}')
+
+    def callback_profile_feature_add(self, msg: ProfileFeatureAdd):
+        face_image = None
+        if msg.face_image.data:
+            try:
+                face_image = self.bridge.compressed_imgmsg_to_cv2(msg.face_image)
+            except Exception as exc:
+                self.get_logger().warn(f'Failed to decode profile face image: {exc}')
+        self.add_profile_feature(msg.user_id, msg.embedding, face_image)
+
+    # 特徴ベクトルを正規化
+    def normalize_features(self, features):
+        features = np.array(features).astype('float32')
+        faiss.normalize_L2(features)  # Faissのnormalize_L2で正規化
+        return features
+    
+    # Faissインデックス作成
+    def create_faiss_index(self, features):
+        # 特徴ベクトルを正規化
+        features = self.normalize_features(features)
+        
+        # FaissのIndexFlatIP（内積）を使用
+        index = faiss.IndexFlatIP(features.shape[1])  # IPは内積（コサイン類似度に対応）
+        
+        # 特徴ベクトルをインデックスに追加
+        index.add(features)
+        
+        return index
+
+    def matching(self, feature1, dictionary, threshold=COSINE_THRESHOLD):
+        """Faissを使ってクエリ特徴と最も類似するユーザーを探す"""
+        
+        # 辞書内のすべての特徴ベクトルを取り出す
+        features_list = []
+        user_ids = []
+        query_dim = np.asarray(feature1, dtype=np.float32).reshape(-1).shape[0]
+        skipped_dim = 0
+
+        for user_id, features in dictionary.items():
+            for feature in features:
+                feature_vec = np.squeeze(np.asarray(feature, dtype=np.float32))
+                if feature_vec.shape[0] != query_dim:
+                    skipped_dim += 1
+                    continue
+                features_list.append(feature_vec)
+                user_ids.append(user_id)  # ユーザーIDを対応付けて追加
+
+        if skipped_dim:
+            self.get_logger().warn(
+                f'Skipped {skipped_dim} dictionary feature(s) with dim != {query_dim}'
+            )
+
+        if not features_list:
+            return "unknown", 0.0
+
+        # Faissインデックス作成（正規化された特徴ベクトルを使う）
+        index = self.create_faiss_index(features_list)
+        
+        # クエリ特徴ベクトルを用意
+        query_feature = np.array(feature1).astype('float32').reshape(1, -1)  # クエリ特徴ベクトルの整形
+        faiss.normalize_L2(query_feature)
+
+        distances, indices = index.search(query_feature, 1)
+        best_score = distances[0][0]
+        best_index = indices[0][0]
+
+        if best_score > threshold:
+            best_user_id = user_ids[best_index]
+            return best_user_id, float(best_score)
+        else:
+            return "unknown", 0.0
+
+    def faiss_fallback_user(
+        self,
+        features: np.ndarray,
+        people_id: str = '',
+        face_id: str = '',
+        threshold: float = COSINE_THRESHOLD,
+        min_vote_ratio: float = FAISS_FALLBACK_MIN_VOTE_RATIO,
+    ) -> str:
+        """LP が unknown のとき、辞書を Faiss で再照合して既存ユーザーを探す。"""
+        pid = people_id or '?'
+        fid = face_id or '?'
+        if not self.dictionary:
+            return "unknown"
+
+        features_list = []
+        user_ids = []
+        query_dim = np.asarray(features[0], dtype=np.float32).reshape(-1).shape[0]
+        skipped_dim = 0
+
+        for user_id, dict_features in self.dictionary.items():
+            for feature in dict_features:
+                feature_vec = np.squeeze(np.asarray(feature, dtype=np.float32))
+                if feature_vec.shape[0] != query_dim:
+                    skipped_dim += 1
+                    continue
+                features_list.append(feature_vec)
+                user_ids.append(user_id)
+
+        if skipped_dim:
+            self.get_logger().warn(
+                f'[Faiss] skipped {skipped_dim} dictionary feature(s) with dim != {query_dim}'
+            )
+        if not features_list:
+            return "unknown"
+
+        index = self.create_faiss_index(features_list)
+        query_features = self.normalize_features(np.asarray(features, dtype=np.float32))
+        distances, indices = index.search(query_features, 1)
+
+        votes: Counter = Counter()
+        n_features = len(query_features)
+        for i in range(n_features):
+            best_score = float(distances[i][0])
+            best_index = int(indices[i][0])
+            if best_score > threshold:
+                votes[user_ids[best_index]] += 1
+
+        if not votes:
+            self.get_logger().info(
+                f'[Faiss] people_id={pid} face_id={fid} LP=unknown, no match above {threshold:g}'
+            )
+            return "unknown"
+
+        best_user, vote_count = votes.most_common(1)[0]
+        if vote_count / n_features < min_vote_ratio:
+            self.get_logger().info(
+                f'[Faiss] people_id={pid} face_id={fid} LP=unknown, weak consensus '
+                f'{best_user}={vote_count}/{n_features} (need >={min_vote_ratio:.0%})'
+            )
+            return "unknown"
+
+        vote_parts = ', '.join(f'{uid}={cnt}' for uid, cnt in votes.most_common(5))
+        self.get_logger().info(
+            f'[Faiss] people_id={pid} face_id={fid} LP=unknown -> {best_user} '
+            f'votes={vote_count}/{n_features} ({vote_parts})'
+        )
+        return best_user
+        
+    def generate_new_user_name(self, dictionary):
+        current_users = [key for key in dictionary.keys() if key.startswith("user_")]
+        
+        # 現在のユーザー数をカウント
+        user_count = len(current_users)
+
+        # 新しいユーザー名を生成
+        return f"user_new{user_count + 1}"
+
+    def callback(self, color_img_src: CompressedImage):
+        self.frame_count_up()
+
+        color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_img_src)
+        cap_height, cap_width = color_img.shape[:2]
+
+        # 検出実施 #############################################################
+        detected_faces = self.insightface.detect_faces(color_img)
+
+        # Create header with timestamp
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()  # Current time
+        header.frame_id = "room_camera1"  # Frame ID        
+        
+        self.recognition_results = FaceRecognitionResult()
+        self.recognition_results.header = header
+
+        for iface_face in detected_faces:
+
+            # 顔の四角形の位置を取得
+            x, y, w, h = iface_face.bbox
+
+            # 顔の座標が画像範囲外にある場合、スキップ
+            if x < 20 or y < 20 or x + w > cap_width -20 or y + h > cap_height -20:
+                continue  # 画面外の顔を無視
+
+            # 検出信頼度が低い顔は照合・辞書蓄積の対象外
+            if iface_face.det_score < MIN_DET_SCORE:
+                continue
+
+            face_info = FaceInfo()
+            face_info.id, face_info.score, face_info.box, face_info.embedding = self.identify_face(iface_face, color_img)
+            face_info.feature_num = self.feature_num
+            self.recognition_results.faces.append(face_info)
+            self.feature_num = self.feature_num + 1
+
+        self.publisher.publish(self.recognition_results)
+
+        # 10秒ごとに辞書更新を実行
+        if time.time() - self.last_renew_time > 10:
+            if self.last_recognition_history is not None:  # 最後に受信したデータが存在する場合のみ更新
+                self.dictionary_renew(self.last_recognition_history)
+                self.last_recognition_history = None  # 更新後にリセット
+            self.last_renew_time = time.time()
+
+    def callback_recognition_history(self, msg: RecognitionHistory):
+        # recognition_history を受け取るが、辞書更新時まで保持しておく
+        self.last_recognition_history = msg  # 最後に受信したデータを保存
+    
+    def identify_face(self, iface_face: InsightFaceResult, image):
+        embedding = iface_face.embedding.copy()
+        box = [int(v) for v in iface_face.bbox]
+        is_frontal = iface_face.is_frontal
+
+        if is_frontal:
+            user_id, score = self.matching(embedding, self.dictionary, COSINE_THRESHOLD)
+            face_id = user_id
+
+            # 特徴とfeature_numをall_featuresに追加
+            self.all_features[self.feature_num] = {
+                "feature": embedding,
+                "user_id": user_id,
+                "score": score
+            }
+
+            x, y, w, h = iface_face.bbox
+            self.all_images[self.feature_num] = image[y:y + h, x:x + w].copy()
+
+            # 描画ノード用に特徴を配信
+            feat_msg = FeatureInfo()
+            feat_msg.feature_num = int(self.feature_num)
+            feat_msg.feature = embedding.astype(np.float32).tolist()
+            self.feature_pub.publish(feat_msg)
+        else:
+            user_id, score = self.matching(embedding, self.profile_dictionary, PROFILE_COSINE_THRESHOLD)
+            face_id = f"{user_id}@profile" if user_id != "unknown" else "unknown@profile"
+
+        return face_id, score, box, embedding.astype(np.float32).tolist()
+            
+    def save_features_for_user(
+        self,
+        user_name: str,
+        features_num: list,
+    ) -> None:
+        """Persist feature_num list to dictionary memory and optionally disk."""
+        # 辞書にユーザーを登録
+        if user_name not in self.dictionary:
+            self.dictionary[user_name] = []
+        self._ensure_profile_user_entry(user_name)
+
+        user_dir = None
+        if self.is_debug_mode:
+            # 新しいディレクトリを作成
+            user_dir = os.path.join(DIRECTORY, user_name)
+            os.makedirs(user_dir, exist_ok=True)
+
+        saved = 0
+        # 特徴ベクトルを保存
+        for num in features_num:
+            if num not in self.all_features:
+                continue
+            feature = self.all_features[num]["feature"]
+            self.dictionary[user_name].append(feature)
+            if self.is_debug_mode and user_dir is not None:
+                # 保存処理
+                feature_path = os.path.join(user_dir, f"{user_name}_{num}.npy")
+                np.save(feature_path, feature)
+                image = self.all_images.get(num)
+                if image is not None:
+                    # 顔画像保存
+                    image_path = os.path.join(user_dir, f"{user_name}_{num}.jpg")
+                    if isinstance(image, np.ndarray):
+                        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+                        Image.fromarray(image).save(image_path, format="JPEG")
+                    else:
+                        image.save(image_path, format="JPEG")
+            # all_features から削除
+            del self.all_features[num]
+            if num in self.all_images:
+                del self.all_images[num]
+            saved += 1
+        if saved:
+            print(
+                f"Saved {saved} feature(s) to {user_name} "
+                f"(total={len(self.dictionary[user_name])})"
+            )
+
+    def dictionary_renew(self, msg: RecognitionHistory):
+        """
+        10秒に1回呼び出される想定の関数。
+        recognition_history.users に格納されている各ユーザーの features_num が
+        MIN_FEATURES_FOR_NEW_USER 件を超えていたら、
+        特徴を辞書に統合 (既存 or 新規) して、その後 all_features から削除する。
+        ラベル伝播法を用いて未ラベルデータにラベルを付け、信頼度が低いものを新規ユーザーとして追加します。
+        face_id ごとに評価し、同一 people_id 内の別 face_id とは混ぜない。
+        """
+        print("辞書の更新を開始します")
+        recognition_history = msg
+
+        # 特徴数とスコアの計算（face_id バケット単位）
+        for user in recognition_history.users:
+            people_id = user.people_id
+
+            for face in user.face_info:
+                # 横顔は数えない
+                if face.id.endswith('@profile'):
+                    continue
+                # 一定数の特徴がないと辞書に登録しない
+                if face.total_features <= MIN_FEATURES_FOR_NEW_USER:
+                    continue
+
+                face_id = face.id
+                features_num = [int(fn) for fn in face.features_num]
+                # features_num の各番号に対応する特徴が存在するかをチェック
+                features_list = [
+                    self.all_features[num]["feature"]
+                    for num in features_num
+                    if num in self.all_features
+                ]
+                # features_list が空でないことを確認してから np.stack を呼び出す
+                if not features_list:
+                    print(
+                        f"{people_id} face_id={face_id}: "
+                        "all_features に該当特徴がありませんでした"
+                    )
+                    continue
+
+                features = np.stack(features_list)
+                best_user = self.label_propagation(
+                    features, people_id=people_id, face_id=face_id
+                )
+                if not best_user:
+                    continue
+
+                faiss_rescued = False
+                if best_user.startswith("unknown"):
+                    faiss_user = self.faiss_fallback_user(
+                        features, people_id=people_id, face_id=face_id
+                    )
+                    if not faiss_user.startswith("unknown"):
+                        best_user = faiss_user
+                        faiss_rescued = True
+
+                print(
+                    f"Selected user: {best_user} "
+                    f"(people_id={people_id}, face_id={face_id}, n={len(features_num)}, "
+                    f"faiss_rescued={faiss_rescued})"
+                )
+
+                # 新しいユーザー登録の条件を満たす場合
+                if best_user.startswith("unknown"):
+                    if face_id != "unknown":
+                        self.get_logger().info(
+                            f'[dict_renew] skip new-user: people_id={people_id} '
+                            f'face_id={face_id} LP=unknown (only unknown bucket registers)'
+                        )
+                        continue
+
+                    new_user_name = self.generate_new_user_name(self.dictionary)
+                    print(f"New user detected: {new_user_name}")
+                    self.save_features_for_user(new_user_name, features_num)
+                    self.rebuild_pca_model_on_disk()
+                    # 辞書内容をトピックで配信
+                    self.update_dictionary(people_id, new_user_name)
+                    continue
+
+                # 既存の user の場合、face_id が LP 結果と一致するときのみ特徴を辞書に追加
+                # Faiss で unknown から救済した場合は face_id=unknown でも既存ユーザーとして扱う
+                if face_id != best_user and not faiss_rescued:
+                    self.get_logger().info(
+                        f'[dict_renew] skip existing-user: people_id={people_id} '
+                        f'face_id={face_id} LP={best_user} (face_id must match)'
+                    )
+                    continue
+
+                average_score = face.accumulate_score / face.total_features
+                print("average_score: ", average_score)
+                if face.accumulate_score > 30 and average_score > 0.6:
+                    self.save_features_for_user(best_user, features_num)
+                    # 辞書内容をトピックで配信
+                    self.update_dictionary(people_id, best_user)
+                else:
+                    self.update_dictionary(people_id, "none")
+
+    def label_propagation(
+        self, unlabeled_features, people_id: str = '', face_id: str = ''
+    ) -> str:
+        labeled_features = []    # 全ラベル付き特徴量
+        labeled_labels = []      # ラベル(数値)
+
+        # ---------- 1) ラベル付きデータの読み込み ----------
+        # self.dictionary からユーザーIDと特徴を抽出
+        user_ids = sorted(self.dictionary.keys())  # すべてのユーザーIDを取得
+        # ユーザーIDから数値ラベルへのマッピングを作る
+        # 例: user_yoki -> 0, user_john -> 1, ...
+        user_id_to_label = {uid: idx for idx, uid in enumerate(sorted(user_ids))}
+        # あとで表示時に数字→名前へ戻すマップ
+        label_to_user_id = {v: k for k, v in user_id_to_label.items()}
+        # 実際の特徴量とラベルを集める
+        for user_id in user_ids:
+            label_value = user_id_to_label[user_id]
+            features = self.dictionary[user_id]
+            for feature in features:
+                labeled_features.append(feature)  # 各ユーザーの特徴ベクトルを追加
+                labeled_labels.append(label_value)  # ラベルを追加
+
+        # 辞書が空のときは LabelPropagation せず新規ユーザー扱いにする
+        if not labeled_features:
+            self.get_logger().warn(
+                f'[LP] people_id={people_id} face_id={face_id} '
+                f'dictionary empty -> unknown (new user)'
+            )
+            return "unknown"
+
+        # ---------- 3) LabelPropagation 用のデータ準備 ----------
+        #  labeled_features + unlabeled_features を連結し、ラベル配列を作る
+        labeled_features = np.vstack(labeled_features).astype(np.float32)
+        all_features = np.vstack([labeled_features, unlabeled_features])
+        num_labeled = len(labeled_features)
+        num_unlabeled = len(unlabeled_features)
+        # 既知ラベル: labeled_labels, 未知ラベル: -1
+        all_labels = np.array(labeled_labels + [-1]*num_unlabeled, dtype=int)
+
+        # ---------- 4) LabelPropagation の実行 ----------
+        # n_neighbors はサンプル数を超えられない（超えると sklearn が ValueError）。
+        # 辞書が小さいうちでも落ちないよう、サンプル数-1 で上限クリップする。
+        n_samples = len(all_features)
+        n_neighbors = max(1, min(100, n_samples - 1))
+        label_prop = LabelPropagation(kernel='knn', n_neighbors=n_neighbors)
+        label_prop.fit(all_features, all_labels)
+        final_labels = label_prop.transduction_
+        # label_distributions_ (各サンプルが各クラスに属する確率分布)
+        label_probs = label_prop.label_distributions_
+                
+        # ---------- 5) 「確信度が低い」サンプルを新規クラスに再割り当て ----------
+        threshold = LP_CONFIDENCE_THRESHOLD
+        existing_max_label = final_labels.max()  # 既存の最大ラベルID
+        new_label_id = existing_max_label + 1    # 新規クラスのラベルID
+        unlabeled_max_probs: list[float] = []
+        low_confidence_count = 0
+        for i, probs in enumerate(label_probs):
+            if all_labels[i] == -1:  # もともと未ラベル
+                max_prob = float(np.max(probs))
+                unlabeled_max_probs.append(max_prob)
+                if max_prob < threshold:
+                    low_confidence_count += 1
+                    final_labels[i] = new_label_id
+
+        # 伝播後のラベルをカウントして最も多いラベルを決定
+        # ここで最も頻繁に現れるラベルを返します
+        label_counts = Counter(final_labels[num_labeled:])  # ラベルなしデータに対応する部分
+        most_common_label, most_common_count = label_counts.most_common(1)[0]  # 最も頻繁に現れるラベルとその数
+
+        # 辞書から指定したキー（ここでは most_common_label）に対応する値を取得します。
+        # もしそのキーが辞書に存在しない場合、2番目の引数（ここでは "unknown"）を返します。
+        most_common_user_id = label_to_user_id.get(most_common_label, "unknown")
+
+        self.log_label_propagation_confidence(
+            people_id=people_id,
+            face_id=face_id,
+            threshold=threshold,
+            num_labeled=num_labeled,
+            unlabeled_max_probs=unlabeled_max_probs,
+            low_confidence_count=low_confidence_count,
+            new_label_id=new_label_id,
+            label_counts=label_counts,
+            label_to_user_id=label_to_user_id,
+            most_common_label=most_common_label,
+            most_common_count=most_common_count,
+            most_common_user_id=most_common_user_id,
+        )
+        return most_common_user_id
+
+    def log_label_propagation_confidence(
+        self,
+        *,
+        people_id: str,
+        face_id: str,
+        threshold: float,
+        num_labeled: int,
+        unlabeled_max_probs: list,
+        low_confidence_count: int,
+        new_label_id: int,
+        label_counts: Counter,
+        label_to_user_id: dict,
+        most_common_label: int,
+        most_common_count: int,
+        most_common_user_id: str,
+    ) -> None:
+        pid = people_id or '?'
+        fid = face_id or '?'
+        n = len(unlabeled_max_probs)
+        if n == 0:
+            self.get_logger().info(f'[LP] people_id={pid} face_id={fid} no unlabeled samples')
+            return
+
+        arr = np.asarray(unlabeled_max_probs, dtype=np.float32)
+        self.get_logger().info(
+            f'[LP] people_id={pid} face_id={fid} threshold={threshold:g} '
+            f'unlabeled={n} dictionary_refs={num_labeled} '
+            f'max_prob min={arr.min():.3f} mean={arr.mean():.3f} max={arr.max():.3f} '
+            f'below_threshold={low_confidence_count}/{n} '
+            f'-> result={most_common_user_id} '
+            f'(votes={most_common_count}/{n}, label_id={most_common_label})'
+        )
+
+        # 確信度ヒストグラム（0.1 刻み）
+        buckets = {f'{lo:.1f}-{hi:.1f}': 0 for lo, hi in zip(np.arange(0, 1, 0.1), np.arange(0.1, 1.1, 0.1))}
+        for p in unlabeled_max_probs:
+            idx = min(int(p * 10), 9)
+            lo = idx / 10
+            hi = lo + 0.1
+            buckets[f'{lo:.1f}-{hi:.1f}'] += 1
+        hist = ' '.join(f'{k}:{v}' for k, v in buckets.items() if v > 0)
+        self.get_logger().info(f'[LP] people_id={pid} face_id={fid} max_prob histogram: {hist}')
+
+        # 投票内訳（上位5）
+        vote_parts = []
+        for label_id, count in label_counts.most_common(5):
+            uid = label_to_user_id.get(label_id, f'new_label_{label_id}')
+            vote_parts.append(f'{uid}={count}')
+        self.get_logger().info(f'[LP] people_id={pid} face_id={fid} label votes: {", ".join(vote_parts)}')
+
+        if low_confidence_count > 0:
+            self.get_logger().info(
+                f'[LP] people_id={pid} face_id={fid} {low_confidence_count} sample(s) '
+                f'max_prob<{threshold:g} -> reassigned to new_label_id={new_label_id} (maps to unknown)'
+            )
+    
+
+    def update_dictionary(self, people_id: str, user_name: str):
+        # user_name が文字列か確認
+        if not isinstance(user_name, str):
+            print(f"Invalid user_name type: {type(user_name)}. Expected 'str'.")
+            return
+        
+        if user_name == "none":
+            print("新しいユーザーは登録されませんでした")
+            
+        # Create header with timestamp
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()  # Current time
+        header.frame_id = "room_camera1"  # Frame ID
+
+        update_msg = DictionaryUpdate()
+        update_msg.header = header
+        update_msg.people_id = people_id
+        update_msg.name = user_name
+        self.update_pub.publish(update_msg)
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    people_recognition_node = PeopleRecognitionNode()
+
+    try:
+        rclpy.spin(people_recognition_node)
+
+    except KeyboardInterrupt:
+        pass
+
+    finally:
+        # 終了処理
+        people_recognition_node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/shigure_core/shigure_core/nodes/node_people_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_people_tracking.py
@@ -1,3 +1,5 @@
+import glob
+import os
 import random
 import re
 from typing import List
@@ -12,11 +14,24 @@ from rclpy.qos import QoSProfile, ReliabilityPolicy
 from openpose_ros2_msgs.msg import PoseKeyPointsList as OpenPosePoseKeyPointsList
 from sensor_msgs.msg import CompressedImage, CameraInfo
 from shigure_core_msgs.msg import PoseKeyPointsList as ShigurePoseKeyPointsList, PoseKeyPoints
+from shigure_core_msgs.msg import FaceRecognitionResult, RecognitionHistory, PeopleFaceInfo, RecInfo, DebugImage
+from shigure_core_msgs.msg import ProfileFeatureAdd, DictionaryUpdate
 
 from shigure_core.nodes.node_image_preview import ImagePreviewNode
 from shigure_core.nodes.people_tracking.logic import PeopleTrackingLogic
 from shigure_core.nodes.people_tracking.tracking_info import TrackingInfo
 from shigure_core.util import compressed_depth_util, pose_key_points_util
+
+# 横顔プロフィール特徴の保存間隔（フレーム）。過剰保存を防ぐ。
+PROFILE_SAVE_INTERVAL_FRAMES = 3
+# 顔辞書(face_models)ディレクトリ。node_face_models / people_recognition と一致させる。
+# SHIGURE_FACE_MODELS_DIR 環境変数があれば最優先。無ければ固定の永続パス ~/.shigure/face_models。
+_env_face_models_dir = os.environ.get('SHIGURE_FACE_MODELS_DIR')
+DIRECTORY = (
+    os.path.expanduser(_env_face_models_dir)
+    if _env_face_models_dir
+    else os.path.expanduser('~/.shigure/face_models')
+)
 
 
 class PeopleTrackingNode(ImagePreviewNode):
@@ -27,10 +42,68 @@ class PeopleTrackingNode(ImagePreviewNode):
         # QoS Settings
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
 
+        # 顔認識結果(体ID→顔ID)の累積履歴。 {people_id: {face_id: {"score", "features_num", "total_features"}}}
+        self.recognition_history = {}
+
+        # 横顔プロフィール保存用の状態
+        self.confirmed_users = {}              # {people_id: 確定 user_name}（/dictionary_update で更新）
+        self.existing_users_at_startup = set()  # 起動時点で登録済みの user_name 集合
+        self._prev_tracked_people_ids = set()   # 直前フレームの追跡ID（消えたIDのクリーンアップ用）
+        self._profile_last_save_frame = {}      # {people_id: 最後に横顔保存したframe_count}
+
+        # 画像保存モード。true のとき追跡デバッグ画像を /shigure/tracking_debug_image に配信し、
+        # ローカルにも保存する（Web表示はこのモードでのみ利用可能）。launch の save_image 引数で切替。
+        self.declare_parameter('save_image', False,
+                               ParameterDescriptor(type=ParameterType.PARAMETER_BOOL,
+                                                   description='true のとき追跡デバッグ画像を配信・保存する（Web表示用）。'))
+        self.save_image: bool = self.get_parameter('save_image').get_parameter_value().bool_value
+
+        # 横顔プロフィール学習。true のとき確定人物の@profile顔特徴を /profile_feature_add へ配信する。
+        # 有効化には color 画像が必要なため、購読条件(is_debug_mode/save_image)にも含める。
+        self.declare_parameter('enable_profile_insightface', False,
+                               ParameterDescriptor(type=ParameterType.PARAMETER_BOOL,
+                                                   description='true のとき横顔プロフィール特徴を /profile_feature_add に配信する。'))
+        self.enable_profile_insightface: bool = \
+            self.get_parameter('enable_profile_insightface').get_parameter_value().bool_value
+        if self.enable_profile_insightface:
+            self._load_existing_users_at_startup()
+
         # publisher, subscriber
         self._publisher = self.create_publisher(
-            ShigurePoseKeyPointsList, 
-            '/shigure/people_detection', 
+            ShigurePoseKeyPointsList,
+            '/shigure/people_detection',
+            10
+        )
+        # 体IDごとの顔ID累積スコアを配信する。people_recognition が名前確定(辞書更新)に使用する
+        self._recognition_history_publisher = self.create_publisher(
+            RecognitionHistory,
+            '/shigure/recognition_history',
+            10
+        )
+        # 顔認識ノード(別ノード)の検出結果を購読し、頭部座標との対応付けで体IDに紐付ける
+        self.face_recognition_sub = self.create_subscription(
+            FaceRecognitionResult,
+            '/face_recognition/results',
+            self.face_recognition_callback,
+            10
+        )
+        # 追跡デバッグ画像(オーバーレイ)の配信先。save_image モード時のみ実際に配信する。
+        self._debug_image_publisher = self.create_publisher(
+            DebugImage,
+            '/shigure/tracking_debug_image',
+            10
+        )
+        # 横顔プロフィール特徴の配信先。people_recognition が購読して辞書へ追加する。
+        self._profile_feature_publisher = self.create_publisher(
+            ProfileFeatureAdd,
+            '/profile_feature_add',
+            10
+        )
+        # 名前確定通知。people_recognition が体ID→確定名を通知する。横顔保存の可否判定に使う。
+        self.dictionary_update_sub = self.create_subscription(
+            DictionaryUpdate,
+            '/dictionary_update',
+            self.update_recognition_history,
             10
         )
         depth_subscriber = message_filters.Subscriber(
@@ -52,15 +125,16 @@ class PeopleTrackingNode(ImagePreviewNode):
             qos_profile=shigure_qos
         )
 
-        if not self.is_debug_mode:
+        # color 画像が必要なのは、描画(is_debug_mode)・画像保存(save_image)・横顔保存(enable_profile_insightface)のいずれか。
+        if not self.is_debug_mode and not self.save_image and not self.enable_profile_insightface:
             self.time_synchronizer = message_filters.TimeSynchronizer(
                 [depth_subscriber, key_points_subscriber, depth_camera_info_subscriber], 30000)
             self.time_synchronizer.registerCallback(self.callback)
         else:
             color_subscriber = message_filters.Subscriber(
-                self, 
-                CompressedImage, 
-                '/rs/color/compressed', 
+                self,
+                CompressedImage,
+                '/rs/color/compressed',
                 qos_profile=shigure_qos
             )
             self.time_synchronizer = message_filters.TimeSynchronizer(
@@ -77,10 +151,14 @@ class PeopleTrackingNode(ImagePreviewNode):
         self.declare_parameter('neck_index', 1,
                                ParameterDescriptor(type=ParameterType.PARAMETER_INTEGER,
                                                    description='追跡基準点とする関節番号（OpenPoseインデックス）。'))
+        self.declare_parameter('face_name_score_threshold', 3.0,
+                               ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE,
+                                                   description='face_name を確定として publish する累積スコアのしきい値（コサイン類似度の累積和）。未満は未確定として空文字を publish する。'))
 
         self.threshold_distance: int = self.get_parameter('threshold_distance').get_parameter_value().integer_value
         self.threshold_person: float = self.get_parameter('threshold_person').get_parameter_value().double_value
         self.neck_index: int = self.get_parameter('neck_index').get_parameter_value().integer_value
+        self.face_name_score_threshold: float = self.get_parameter('face_name_score_threshold').get_parameter_value().double_value
 
         self.add_on_set_parameters_callback(self._on_set_parameters_people_tracking)
 
@@ -108,7 +186,202 @@ class PeopleTrackingNode(ImagePreviewNode):
             elif param.name == 'neck_index':
                 self.neck_index = param.value
                 self.get_logger().info('NeckIndex : ' + str(self.neck_index))
+            elif param.name == 'face_name_score_threshold':
+                self.face_name_score_threshold = param.value
+                self.get_logger().info('FaceNameScoreThreshold : ' + str(self.face_name_score_threshold))
+            elif param.name == 'save_image':
+                # 実行中の切替も反映するが、color購読は起動時に決まるため、保存/配信を実際に
+                # 行えるのは起動時から is_debug_mode か save_image が有効だった場合に限る。
+                self.save_image = param.value
+                self.get_logger().info('SaveImage : ' + str(self.save_image))
+            elif param.name == 'enable_profile_insightface':
+                # color購読は起動時に決まるため、起動時から有効だった場合のみ実際に横顔保存できる。
+                self.enable_profile_insightface = param.value
+                self.get_logger().info('EnableProfileInsightface : ' + str(self.enable_profile_insightface))
         return SetParametersResult(successful=True)
+
+    @staticmethod
+    def is_point_in_box(point, box):
+        """点(x, y)が矩形box=[x, y, w, h]の内側にあるか判定する."""
+        x, y = point
+        box_x, box_y, box_width, box_height = box
+        return box_x <= x <= box_x + box_width and box_y <= y <= box_y + box_height
+
+    def face_recognition_callback(self, msg: FaceRecognitionResult):
+        """
+        顔認識ノードの検出結果を受け取り、各顔と追跡中の人物(体ID)を頭部座標で対応付ける.
+
+        頭部キーポイント(OpenPoseインデックス0)が顔boxに入っていれば、その体IDに顔IDのスコアを
+        フレームをまたいで累積する。単発ではなく累積投票で確からしさを高める。
+        """
+        # 横顔プロフィール保存で参照するため、最新の顔検出結果を保持する。
+        self.current_face_data = msg
+        for face_info in msg.faces:
+            face_id = face_info.id
+            score = face_info.score
+            feature_num = face_info.feature_num
+            face_box = list(face_info.box)
+            # box は [x, y, w, h] を想定。異常な長さは対応付け不能なのでスキップする。
+            if len(face_box) != 4:
+                continue
+
+            for people_id, people in self.tracking_info.get_people_dict().items():
+                openpose_pose_key_points = people[-1]
+                if not openpose_pose_key_points.pose_key_points:
+                    continue
+                head = openpose_pose_key_points.pose_key_points[0]
+                head_point = (head.x, head.y)
+
+                if PeopleTrackingNode.is_point_in_box(head_point, face_box):
+                    bucket = self.recognition_history.setdefault(people_id, {})
+                    if face_id in bucket:
+                        bucket[face_id]['score'] += score
+                        bucket[face_id]['features_num'].append(feature_num)
+                        bucket[face_id]['total_features'] += 1
+                    else:
+                        bucket[face_id] = {
+                            'score': score,
+                            'features_num': [feature_num],
+                            'total_features': 1,
+                        }
+
+        self._recognition_history_publisher.publish(self.create_recognition_history_message())
+
+    def create_recognition_history_message(self) -> RecognitionHistory:
+        """内部の累積履歴(recognition_history)を RecognitionHistory メッセージへ変換する."""
+        recognition_history_msg = RecognitionHistory()
+        recognition_history_msg.users = []
+
+        for people_id, faces in self.recognition_history.items():
+            people_face_info = PeopleFaceInfo()
+            people_face_info.people_id = people_id
+            people_face_info.face_info = []
+            for face_id, data in faces.items():
+                rec_info = RecInfo()
+                rec_info.id = face_id
+                rec_info.features_num = data.get('features_num', [])
+                rec_info.total_features = data['total_features']
+                rec_info.accumulate_score = data['score']
+                people_face_info.face_info.append(rec_info)
+            recognition_history_msg.users.append(people_face_info)
+
+        return recognition_history_msg
+
+    def get_most_likely_face_id(self, people_id):
+        """体IDに対し、累積スコアが最大の顔ID(名前)とそのスコアを返す。履歴が無ければ(None, 0)を返す."""
+        faces = self.recognition_history.get(people_id)
+        if not faces:
+            return None, 0.0
+        most_likely_id, data = max(faces.items(), key=lambda item: item[1]['score'])
+        display_id = most_likely_id.replace('@profile', '')
+        return display_id, data['score']
+
+    def _cleanup_recognition_history(self):
+        """現在追跡していない体IDの顔認識履歴・確定名・横顔保存状態を破棄する."""
+        current_ids = set(self.tracking_info.get_people_dict().keys())
+        for people_id in list(self.recognition_history.keys()):
+            if people_id not in current_ids:
+                del self.recognition_history[people_id]
+        # 横顔プロフィール保存の状態も、追跡から外れた体IDについて破棄する。
+        lost_ids = self._prev_tracked_people_ids - current_ids
+        for people_id in lost_ids:
+            self.confirmed_users.pop(people_id, None)
+            self._profile_last_save_frame.pop(people_id, None)
+        self._prev_tracked_people_ids = current_ids
+
+    def _load_existing_users_at_startup(self):
+        """起動時点で登録済みの user_* を読み込む."""
+        user_dirs = glob.glob(os.path.join(DIRECTORY, 'user_*'))
+        self.existing_users_at_startup = {os.path.basename(path) for path in user_dirs}
+
+    def update_recognition_history(self, msg: DictionaryUpdate):
+        """people_recognition からの確定名通知(/dictionary_update)を受け、確定名を保持する."""
+        update_people_id = msg.people_id
+        new_user_name = msg.name
+        self.get_logger().info(f'Received user name: {new_user_name} in {update_people_id}')
+
+        if new_user_name != 'none':
+            self.confirmed_users[update_people_id] = new_user_name
+            if new_user_name.startswith('user_new'):
+                self.existing_users_at_startup.add(new_user_name)
+
+    def can_save_profile(self, people_id, user_name):
+        """骨格IDとユーザー名が confirmed_users で一致していれば横顔保存可."""
+        if not user_name or user_name == 'unknown' or not user_name.startswith('user'):
+            return False
+        return self.confirmed_users.get(people_id) == user_name
+
+    def _try_save_profile_feature(self, people_id, user_name, embedding, face_image=None):
+        """保存間隔(PROFILE_SAVE_INTERVAL_FRAMES)を守りつつ横顔特徴を配信する."""
+        last_frame = self._profile_last_save_frame.get(people_id, -PROFILE_SAVE_INTERVAL_FRAMES)
+        if self.frame_count - last_frame < PROFILE_SAVE_INTERVAL_FRAMES:
+            return
+        self._publish_profile_feature_add(user_name, embedding, face_image)
+        self._profile_last_save_frame[people_id] = self.frame_count
+
+    def _publish_profile_feature_add(self, user_name, embedding, face_image=None):
+        """横顔特徴(埋め込み＋任意で顔画像)を /profile_feature_add へ配信する."""
+        msg = ProfileFeatureAdd()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.user_id = user_name
+        msg.embedding = np.asarray(embedding, dtype=np.float32).reshape(-1).tolist()
+        if face_image is not None and face_image.size > 0:
+            msg.face_image = self.bridge.cv2_to_compressed_imgmsg(face_image)
+        self._profile_feature_publisher.publish(msg)
+        self.get_logger().info(f'Published profile feature add: user_id={user_name}')
+
+    def _process_profile_save(self, published_msg: ShigurePoseKeyPointsList, color_img=None):
+        """確定人物について、頭部と重なる @profile 顔の特徴を横顔として保存配信する."""
+        current_face_data = getattr(self, 'current_face_data', None)
+        if current_face_data is None:
+            return
+
+        people_dict = self.tracking_info.get_people_dict()
+        for pose_key_points in published_msg.pose_key_points_list:
+            people_id = pose_key_points.people_id
+            if people_id not in people_dict:
+                continue
+
+            confirmed_user_id = self.confirmed_users.get(people_id)
+            if not self.can_save_profile(people_id, confirmed_user_id or ''):
+                continue
+
+            openpose_pose_key_points = people_dict[people_id][-1]
+            if not openpose_pose_key_points.pose_key_points:
+                continue
+            head_point = openpose_pose_key_points.pose_key_points[0]
+            head = (head_point.x, head_point.y)
+
+            for face_info in current_face_data.faces:
+                if not face_info.id.endswith('@profile'):
+                    continue
+                face_box = list(face_info.box)
+                if len(face_box) != 4:
+                    continue
+                if not PeopleTrackingNode.is_point_in_box(head, face_box):
+                    continue
+                if not face_info.embedding:
+                    continue
+
+                embedding = np.asarray(face_info.embedding, dtype=np.float32)
+                face_crop = self._crop_face(color_img, face_box)
+                self._try_save_profile_feature(people_id, confirmed_user_id, embedding, face_crop)
+                break
+
+    @staticmethod
+    def _crop_face(color_img, box):
+        """color_img から box=[x, y, w, h] で顔領域を切り出す。範囲外は None."""
+        if color_img is None:
+            return None
+        height, width = color_img.shape[:2]
+        x, y, w, h = [int(v) for v in box]
+        left = max(0, x)
+        top = max(0, y)
+        right = min(width, x + w)
+        bottom = min(height, y + h)
+        if right <= left or bottom <= top:
+            return None
+        return color_img[top:bottom, left:right].copy()
 
     def callback(self, depth_src: CompressedImage, key_points_list: OpenPosePoseKeyPointsList, camera_info: CameraInfo):
         self.frame_count_up()
@@ -127,6 +400,9 @@ class PeopleTrackingNode(ImagePreviewNode):
             self.threshold_distance, self.threshold_person, self.neck_index
         )
 
+        # 追跡から外れた体IDの顔認識履歴を破棄（メモリ肥大・IDの使い回し対策）
+        self._cleanup_recognition_history()
+
         # publish
         publish_msg = ShigurePoseKeyPointsList()
         publish_msg.header = key_points_list.header
@@ -135,6 +411,10 @@ class PeopleTrackingNode(ImagePreviewNode):
             _, _, _, openpose_pose_key_points = people
             shigure_pose_key_points = pose_key_points_util.convert_openpose_to_shigure(openpose_pose_key_points,
                                                                                        depth_img, people_id, k)
+            # 顔認識で対応が取れた名前(顔ID)を付与する。しきい値未満は未確定として空のまま。
+            face_name, score = self.get_most_likely_face_id(people_id)
+            if face_name is not None and score >= self.face_name_score_threshold:
+                shigure_pose_key_points.face_name = face_name
             publish_msg.pose_key_points_list.append(shigure_pose_key_points)
         self._publisher.publish(publish_msg)
 
@@ -144,11 +424,35 @@ class PeopleTrackingNode(ImagePreviewNode):
                        camera_info: CameraInfo, color_src: CompressedImage):
         published_msg: ShigurePoseKeyPointsList = self.callback(depth_src, key_points_list, camera_info)
 
-        if not self.is_debug_mode:
+        color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_src)
+
+        # 横顔プロフィール保存（描画前の生画像から切り出すため、_draw_overlay より先に行う）
+        if self.enable_profile_insightface:
+            self._process_profile_save(published_msg, color_img)
+
+        # デバッグ表示も画像保存も不要なら描画はしない（ウィンドウは閉じる）
+        if not self.is_debug_mode and not self.save_image:
             cv2.destroyAllWindows()
             return
 
-        color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_src)
+        self._draw_overlay(color_img, published_msg)
+        self.print_fps(color_img)
+
+        # デバッグウィンドウ表示（is_debug_mode のときのみ）
+        if self.is_debug_mode:
+            cv2.namedWindow('people_tracking', cv2.WINDOW_NORMAL)
+            cv2.imshow('people_tracking', color_img)
+            cv2.waitKey(1)
+        else:
+            cv2.destroyAllWindows()
+
+        # 画像保存モード: 追跡デバッグ画像を配信・保存する（Web表示用）。負荷軽減のため5フレーム毎。
+        if self.save_image and self.frame_count % 5 == 0:
+            self._publish_tracking_debug_image(color_img)
+            self._save_tracking_debug_image(color_img)
+
+    def _draw_overlay(self, color_img: np.ndarray, published_msg: ShigurePoseKeyPointsList) -> None:
+        """追跡結果(バウンディングボックスとID/顔名ラベル)を color_img へ描画する."""
         height, width = color_img.shape[:2]
 
         pose_key_points: PoseKeyPoints
@@ -171,18 +475,41 @@ class PeopleTrackingNode(ImagePreviewNode):
 
             people_id_num = int(re.sub(".*_", "", people_id))
             color = self._colors[people_id_num % 255]
+            # 顔認識で名前が確定していれば名前を、無ければ体IDを表示する（オクルージョンによるID変化を吸収）
+            label = pose_key_points.face_name if pose_key_points.face_name else f'ID : {people_id_num}'
             cv2.circle(color_img, (x, y), 5, color, thickness=-1)
             cv2.rectangle(color_img, (left, top), (right, bottom), color, thickness=3)
-            text_w, text_h = cv2.getTextSize(f'ID : {people_id_num}',
+            text_w, text_h = cv2.getTextSize(label,
                                              cv2.FONT_HERSHEY_PLAIN, 1.5, 2)[0]
             cv2.rectangle(color_img, (left, top), (left + text_w, top - text_h), color, -1)
-            cv2.putText(color_img, f'ID : {people_id_num}', (left, top),
+            cv2.putText(color_img, label, (left, top),
                         cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
 
-        self.print_fps(color_img)
-        cv2.namedWindow('people_tracking', cv2.WINDOW_NORMAL)
-        cv2.imshow('people_tracking', color_img)
-        cv2.waitKey(1)
+    def _publish_tracking_debug_image(self, color_img: np.ndarray) -> None:
+        """オーバーレイ画像を JPEG エンコードして /shigure/tracking_debug_image に配信する(Web表示用)."""
+        ok, buf = cv2.imencode('.jpg', color_img, [int(cv2.IMWRITE_JPEG_QUALITY), 85])
+        if not ok:
+            return
+        msg = DebugImage()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = str(self.frame_count)
+        msg.format = 'jpeg'
+        msg.data = buf.tobytes()
+        self._debug_image_publisher.publish(msg)
+
+    def _save_tracking_debug_image(self, color_img: np.ndarray) -> None:
+        """オーバーレイ画像をローカルの debug_images ディレクトリへ保存する."""
+        if not hasattr(self, '_debug_image_dir'):
+            # shigure_core パッケージ直下の debug_images/people_tracking を保存先とする。
+            base = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'debug_images')
+            self._debug_image_dir = os.path.abspath(os.path.join(base, 'people_tracking'))
+            os.makedirs(self._debug_image_dir, exist_ok=True)
+            self.get_logger().info(f'追跡デバッグ画像を保存: {self._debug_image_dir}')
+        cv2.imwrite(os.path.join(self._debug_image_dir, 'people_tracking_latest.jpg'), color_img)
+        cv2.imwrite(
+            os.path.join(self._debug_image_dir, f'people_tracking_{self.frame_count:06d}.jpg'),
+            color_img,
+        )
 
 
 def main(args=None):

--- a/shigure_core/shigure_core/nodes/profile_insightface.py
+++ b/shigure_core/shigure_core/nodes/profile_insightface.py
@@ -1,0 +1,137 @@
+"""InsightFace (SCRFD + ArcFace) wrapper for profile-face detection and embedding."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+FRONTAL_YAW_THRESHOLD = 30.0
+
+
+@dataclass
+class InsightFaceResult:
+    """Detected profile face with ArcFace embedding."""
+
+    bbox: Tuple[int, int, int, int]  # x, y, w, h in full image coordinates
+    embedding: np.ndarray
+    det_score: float
+    yaw: float = 0.0
+    pitch: float = 0.0
+    roll: float = 0.0
+
+    @property
+    def is_frontal(self) -> bool:
+        return ProfileInsightFace.is_frontal(self.yaw)
+
+
+class ProfileInsightFace:
+    """Lazy-loaded InsightFace detector for YuNet fallback."""
+
+    def __init__(self, det_size: Tuple[int, int] = (640, 640)):
+        self._det_size = det_size
+        self._app = None
+        self._available = None
+
+    @property
+    def available(self) -> bool:
+        if self._available is None:
+            try:
+                import insightface  # noqa: F401
+                self._available = True
+            except ImportError:
+                self._available = False
+        return self._available
+
+    def _ensure_app(self):
+        if self._app is not None:
+            return
+        if not self.available:
+            raise RuntimeError("insightface is not installed")
+        from insightface.app import FaceAnalysis
+
+        # 実行デバイスを選択する。
+        #   SHIGURE_INSIGHTFACE_DEVICE=cpu/gpu で明示指定可。未指定なら CUDA が使えれば GPU、
+        #   無ければ CPU に自動フォールバックする（GPU 必須ではない）。
+        device = os.environ.get('SHIGURE_INSIGHTFACE_DEVICE', 'auto').lower()
+        use_gpu = False
+        if device == 'gpu':
+            use_gpu = True
+        elif device == 'cpu':
+            use_gpu = False
+        else:
+            try:
+                import onnxruntime as ort
+                use_gpu = 'CUDAExecutionProvider' in ort.get_available_providers()
+            except Exception:
+                use_gpu = False
+
+        if use_gpu:
+            self._app = FaceAnalysis(
+                name='buffalo_s',
+                providers=['CUDAExecutionProvider', 'CPUExecutionProvider'],
+            )
+            self._app.prepare(ctx_id=0, det_size=self._det_size)
+        else:
+            self._app = FaceAnalysis(name='buffalo_s', providers=['CPUExecutionProvider'])
+            self._app.prepare(ctx_id=-1, det_size=self._det_size)
+
+    @staticmethod
+    def is_frontal(yaw: float, threshold: float = FRONTAL_YAW_THRESHOLD) -> bool:
+        return abs(yaw) < threshold
+
+    @staticmethod
+    def is_point_in_box(point: Tuple[float, float], box: Tuple[int, int, int, int]) -> bool:
+        x, y = point
+        box_x, box_y, box_width, box_height = box
+        return box_x <= x <= box_x + box_width and box_y <= y <= box_y + box_height
+
+    def detect_faces(self, image: np.ndarray) -> List[InsightFaceResult]:
+        """全画面で顔検出し、bbox と embedding の一覧を返す（YuNet と同じ起点）。"""
+        if image is None or image.size == 0:
+            return []
+
+        self._ensure_app()
+        faces = self._app.get(image)
+        results: List[InsightFaceResult] = []
+        for face in faces:
+            x1, y1, x2, y2 = face.bbox.astype(int)
+            w = max(1, x2 - x1)
+            h = max(1, y2 - y1)
+            embedding = np.asarray(face.embedding, dtype=np.float32).reshape(-1)
+            det_score = float(getattr(face, "det_score", 0.0))
+            pitch, yaw, roll = 0.0, 0.0, 0.0
+            pose = getattr(face, "pose", None)
+            if pose is not None and len(pose) >= 3:
+                pitch, yaw, roll = float(pose[0]), float(pose[1]), float(pose[2])
+            results.append(InsightFaceResult(
+                bbox=(x1, y1, w, h),
+                embedding=embedding,
+                det_score=det_score,
+                yaw=yaw,
+                pitch=pitch,
+                roll=roll,
+            ))
+        return results
+
+    def find_face_for_head(
+        self,
+        faces: List[InsightFaceResult],
+        head_point,
+    ) -> Optional[InsightFaceResult]:
+        """
+        検出済みの顔 bbox 一覧から、頭部座標が bbox 内にある顔を返す（YuNet 側の紐付けと同じ）。
+        複数候補がある場合は det_score が最も高い顔を採用する。
+        """
+        head = (head_point.x, head_point.y)
+        best: Optional[InsightFaceResult] = None
+        best_score = -1.0
+        for candidate in faces:
+            if not self.is_point_in_box(head, candidate.bbox):
+                continue
+            if candidate.det_score > best_score:
+                best = candidate
+                best_score = candidate.det_score
+        return best

--- a/shigure_core/shigure_core/util/pca_model.py
+++ b/shigure_core/shigure_core/util/pca_model.py
@@ -1,0 +1,137 @@
+"""Build pca_model.pkl from face_models/*.npy (frontal + profile)."""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class PcaBuildResult:
+    success: bool
+    output_path: Path
+    num_samples: int = 0
+    num_users: int = 0
+    message: str = ''
+
+
+def count_user_dirs(face_models_dir: Path) -> int:
+    if not face_models_dir.is_dir():
+        return 0
+    return sum(1 for p in face_models_dir.glob('user_*') if p.is_dir())
+
+
+def iter_embedding_paths(face_models_dir: Path) -> Iterator[Path]:
+    """Yield frontal and profile .npy paths under user_* directories."""
+    if not face_models_dir.is_dir():
+        return
+    for user_dir in sorted(face_models_dir.glob('user_*')):
+        if not user_dir.is_dir():
+            continue
+        for npy_path in sorted(user_dir.glob('*.npy')):
+            yield npy_path
+        profile_dir = user_dir / 'profile'
+        if profile_dir.is_dir():
+            for npy_path in sorted(profile_dir.glob('*.npy')):
+                yield npy_path
+
+
+def user_id_for_npy(npy_path: Path) -> str:
+    if npy_path.parent.name == 'profile':
+        return npy_path.parent.parent.name
+    return npy_path.parent.name
+
+
+def load_embeddings_matrix(face_models_dir: Path) -> tuple[np.ndarray, int]:
+    vectors: list[np.ndarray] = []
+    user_ids: set[str] = set()
+    for npy_path in iter_embedding_paths(face_models_dir):
+        user_ids.add(user_id_for_npy(npy_path))
+        raw = np.squeeze(np.load(npy_path)).astype(np.float32).reshape(-1)
+        if raw.size == 0:
+            continue
+        vectors.append(raw)
+    if not vectors:
+        return np.empty((0, 0), dtype=np.float32), 0
+    lengths = {v.shape[0] for v in vectors}
+    if len(lengths) != 1:
+        dim = max(lengths)
+        vectors = [v for v in vectors if v.shape[0] == dim]
+    if not vectors:
+        return np.empty((0, 0), dtype=np.float32), len(user_ids)
+    return np.vstack(vectors), len(user_ids)
+
+
+def default_pca_model_path(face_models_dir: Path) -> Path:
+    return face_models_dir / 'pca_model.pkl'
+
+
+def build_pca_model(
+    face_models_dir: Path,
+    output_path: Optional[Path] = None,
+    *,
+    n_components: int = 2,
+) -> PcaBuildResult:
+    """Fit sklearn PCA on all embeddings and write pca_model.pkl."""
+    from sklearn.decomposition import PCA
+
+    face_models_dir = Path(face_models_dir)
+    out = Path(output_path) if output_path is not None else default_pca_model_path(face_models_dir)
+
+    matrix, num_users = load_embeddings_matrix(face_models_dir)
+    if matrix.shape[0] < n_components:
+        return PcaBuildResult(
+            success=False,
+            output_path=out,
+            num_samples=int(matrix.shape[0]),
+            num_users=num_users,
+            message=f'need at least {n_components} samples, got {matrix.shape[0]}',
+        )
+
+    pca = PCA(n_components=n_components)
+    pca.fit(matrix.astype(np.float32))
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, 'wb') as f:
+        pickle.dump(pca, f)
+
+    return PcaBuildResult(
+        success=True,
+        output_path=out,
+        num_samples=int(matrix.shape[0]),
+        num_users=num_users,
+        message=f'wrote {out} ({matrix.shape[0]} samples, {num_users} users, dim={matrix.shape[1]})',
+    )
+
+
+def main() -> None:
+    import argparse
+
+    # SHIGURE_FACE_MODELS_DIR 環境変数があれば最優先、無ければ固定の永続パス ~/.shigure/face_models。
+    import os
+    _env = os.environ.get('SHIGURE_FACE_MODELS_DIR')
+    default_face_models_dir = (
+        Path(_env).expanduser() if _env
+        else Path('~/.shigure/face_models').expanduser()
+    )
+
+    parser = argparse.ArgumentParser(description='Rebuild pca_model.pkl from face_models')
+    parser.add_argument(
+        '--face-models-dir',
+        type=Path,
+        default=default_face_models_dir,
+    )
+    parser.add_argument('--output', type=Path, default=None)
+    args = parser.parse_args()
+    result = build_pca_model(args.face_models_dir, args.output)
+    print(result.message)
+    if not result.success:
+        raise SystemExit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/shigure_core_msgs/CMakeLists.txt
+++ b/shigure_core_msgs/CMakeLists.txt
@@ -42,6 +42,15 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/HeaderString.msg"
   "msg/SelectObject.msg"
   "msg/SelectObjectList.msg"
+  "msg/FaceInfo.msg"
+  "msg/FaceRecognitionResult.msg"
+  "msg/RecInfo.msg"
+  "msg/PeopleFaceInfo.msg"
+  "msg/RecognitionHistory.msg"
+  "msg/DictionaryUpdate.msg"
+  "msg/FeatureInfo.msg"
+  "msg/DebugImage.msg"
+  "msg/ProfileFeatureAdd.msg"
   DEPENDENCIES builtin_interfaces std_msgs sensor_msgs
 )
 

--- a/shigure_core_msgs/msg/DebugImage.msg
+++ b/shigure_core_msgs/msg/DebugImage.msg
@@ -1,0 +1,14 @@
+# This message contains a debug image.
+
+std_msgs/Header header # Header timestamp should be acquisition time of image
+                             # Header frame_id should be optical frame of camera
+                             # origin of frame should be optical center of cameara
+                             # +x should point to the right in the image
+                             # +y should point down in the image
+                             # +z should point into to plane of the image
+
+string format                # Specifies the format of the data
+                             #   Acceptable values:
+                             #     jpeg, png
+
+uint8[] data                 # Compressed image buffer

--- a/shigure_core_msgs/msg/DictionaryUpdate.msg
+++ b/shigure_core_msgs/msg/DictionaryUpdate.msg
@@ -1,0 +1,3 @@
+std_msgs/Header header
+string people_id
+string name

--- a/shigure_core_msgs/msg/FaceInfo.msg
+++ b/shigure_core_msgs/msg/FaceInfo.msg
@@ -1,0 +1,5 @@
+int32 feature_num
+string id
+float64 score
+int32[] box
+float32[] embedding

--- a/shigure_core_msgs/msg/FeatureInfo.msg
+++ b/shigure_core_msgs/msg/FeatureInfo.msg
@@ -1,0 +1,2 @@
+int32 feature_num
+float32[] feature

--- a/shigure_core_msgs/msg/PeopleFaceInfo.msg
+++ b/shigure_core_msgs/msg/PeopleFaceInfo.msg
@@ -1,0 +1,2 @@
+string people_id
+RecInfo[] face_info

--- a/shigure_core_msgs/msg/PoseKeyPoints.msg
+++ b/shigure_core_msgs/msg/PoseKeyPoints.msg
@@ -1,3 +1,4 @@
 string people_id
+string face_name
 BoundingBox bounding_box
 PointData[] point_data

--- a/shigure_core_msgs/msg/ProfileFeatureAdd.msg
+++ b/shigure_core_msgs/msg/ProfileFeatureAdd.msg
@@ -1,0 +1,4 @@
+std_msgs/Header header
+string user_id
+float32[] embedding
+sensor_msgs/CompressedImage face_image

--- a/shigure_core_msgs/msg/RecInfo.msg
+++ b/shigure_core_msgs/msg/RecInfo.msg
@@ -1,0 +1,4 @@
+string id
+int32[] features_num
+int32 total_features
+float64 accumulate_score

--- a/shigure_core_msgs/msg/RecognitionHistory.msg
+++ b/shigure_core_msgs/msg/RecognitionHistory.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+PeopleFaceInfo[] users


### PR DESCRIPTION
別リポジトリ（顔認識搭載の旧shigure）から、現行 YOLO11 版 shigure_core へ顔認識機能を統合

顔認識用メッセージ型9種類の追加(FaceInfo FaceRecognitionResult RecInfo PeopleFaceInfo RecognitionHistory DictionaryUpdate FeatureInfo DebugImage ProfileFeatureAdd)

PoseKeyPoints.msgのフィールドにface_name(骨格との対応がとれた顔のID)を追加

people_tracking ノードの改修
 ・顔:left_right_arrow:骨格の対応付け：/face_recognition/results を購読 → 頭部キーポイント(index0)が顔box内なら recognition_history にコサインスコアを累積
 ・face_name 付与：累積スコア ≥ face_name_score_threshold で PoseKeyPoints.face_name にセット
 ・/shigure/recognition_history を publish（people_recognition の辞書更新用）
 ・save_image モード：/shigure/tracking_debug_image(DebugImage) 配信

ノード移植(people_recognition，node_face_models，profile_insightface，util/pca_model)

shigure_apiパッケージ(FAST APIを利用して顔登録結果をWebUIで確認)

shigure_core_launch.pyに実行時オプション追加
 ・debug_mode(デフォルトはFalse) 顔データの登録機能実行，全ノードのcv2window起動
 ・save_image(デフォルトはFalse) 全体画像保存，shigure_apiの実行可能化
 ・enable_profile(デフォルトはFalse) 横顔保存

パラメータチューニング(people_recognition ノード)
 ・face_name_score_threshold(顔 to 骨格対応のためのコサイン類似度累積和のしきい値) 100→3
 ・MIN_FEATURES_FOR_NEW_USER (新規人物の自動登録のための最低特徴数) 50→20
 Dynamic Reconfigure対応済み