### PR TITLE
モード切り替え実装，Fast API画像送信永続化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,12 @@ DISPLAY=:0
 ROS_DOMAIN_ID=10
 
 # --- 起動モード（docker compose の launch 引数。省略時は右のデフォルト値） ---
-# cv2デバッグ窓の表示・自動登録ユーザーのディスク保存（デフォルト: true）
+# ※ いずれも起動時の初期値。稼働中は再起動なしに ros2 param set で切替可能。
+# cv2デバッグ窓の表示のみ（顔データ保存は伴わない。デフォルト: true）
 DEBUG_MODE=true
-# 追跡デバッグ画像の配信 + Web API(shigure_api, ポート8765)の起動（デフォルト: false）
+# 追跡デバッグ画像をローカルディスクに保存（手元解析用。Web配信は常時なので無関係。デフォルト: false）
 SAVE_IMAGE=false
 # 横顔プロフィール特徴の配信・学習（デフォルト: false）
 ENABLE_PROFILE=false
+# 自動登録ユーザーの顔特徴・画像・PCAモデルのディスク保存（DEBUG_MODEとは独立。デフォルト: false）
+SAVE_REGISTRATION=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,6 @@ Node / Logic 層の分離・新ノード登録・動的パラメータ（reconfi
 ## 注意事項
 
 - launch は各ノードを端末エミュレータの別ウィンドウで起動する（`terminal:=gnome-terminal/xterm/none` で切替、Docker は xterm）。ヘッドレス環境は `terminal:=none`
-- Docker の launch 引数は docker-compose.yml の `command:` 経由で .env の `DEBUG_MODE` / `SAVE_IMAGE` / `ENABLE_PROFILE` から渡る
+- Docker の launch 引数は docker-compose.yml の `command:` 経由で .env の `DEBUG_MODE` / `ENABLE_PROFILE` / `SAVE_IMAGE` / `SAVE_REGISTRATION` から渡る
 - numpy 2 系は非対応（Dockerfile で `numpy<2` に固定）
 - ノードのしきい値類は Logic 層にハードコードされているものが多い。パラメータを探すときは node 層だけでなく `nodes/<name>/logic.py` も確認する

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,14 @@ services:
   shigure_core:
     build: .
     network_mode: host
-    # launch引数は .env の DEBUG_MODE / SAVE_IMAGE / ENABLE_PROFILE で変更できる
+    # launch引数は .env の DEBUG_MODE / ENABLE_PROFILE / SAVE_IMAGE / SAVE_REGISTRATION で変更できる
     command: >
       ros2 launch shigure_core shigure_core_launch.py
       terminal:=xterm record:=true save_root_path:=/ros2_ws/events
       debug_mode:=${DEBUG_MODE:-true}
-      save_image:=${SAVE_IMAGE:-false}
       enable_profile:=${ENABLE_PROFILE:-false}
+      save_image:=${SAVE_IMAGE:-false}
+      save_registration:=${SAVE_REGISTRATION:-false}
     environment:
       - DISPLAY=${DISPLAY}
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}

--- a/docs/setup-docker.md
+++ b/docs/setup-docker.md
@@ -55,7 +55,7 @@ docker compose up           # 2回目以降（コード変更なし）
 | people_tracking / people_recognition | 人物追跡・顔認識 |
 | contact_detection | 接触イベント判定 |
 | pose_save / record_event | 骨格・イベントの DB 保存 |
-| shigure_api | Web API（`SAVE_IMAGE=true` のときのみ起動、ポート 8765） |
+| shigure_api | Web API（常駐、ポート 8765）。全体画像(現フレーム)は常時配信される |
 
 顔辞書はホストの `~/.shigure` をマウントしているため、コンテナを作り直しても登録ユーザーは残る。
 
@@ -63,11 +63,14 @@ docker compose up           # 2回目以降（コード変更なし）
 
 launch 引数は .env で変更できる（docker compose が起動時に launch へ渡す）：
 
+いずれも**起動時の初期値**で、稼働中は再起動なしに `ros2 param set` で切替可能（[usage.md の「実行中のモード切替」](usage.md#実行中のモード切替長期稼働時のストレージ制御)参照）。
+
 | 変数 | デフォルト | 効果 |
 | :--- | :--- | :--- |
-| `DEBUG_MODE` | true | cv2 デバッグ窓の表示・自動登録ユーザーのディスク保存 |
-| `SAVE_IMAGE` | false | 追跡デバッグ画像の配信 + Web API(shigure_api) の起動 |
+| `DEBUG_MODE` | true | cv2 デバッグ窓の**表示のみ**（顔データ保存は伴わない） |
 | `ENABLE_PROFILE` | false | 横顔プロフィール特徴の配信・学習 |
+| `SAVE_IMAGE` | false | 追跡デバッグ画像をローカルディスクに保存（手元解析用。Web 配信は常時なので無関係） |
+| `SAVE_REGISTRATION` | false | 自動登録ユーザーの顔特徴・画像・PCA モデルのディスク保存（`DEBUG_MODE` とは独立） |
 
 変更後は `docker compose up` で再作成すれば反映される（イメージ再ビルドは不要）。
 

--- a/docs/setup-native.md
+++ b/docs/setup-native.md
@@ -65,19 +65,24 @@ docker compose up -d db migrate
 ## 5. 認識パイプラインの起動
 
 ```sh
-ros2 launch shigure_core shigure_core_launch.py debug_mode:=true save_image:=true
+ros2 launch shigure_core shigure_core_launch.py debug_mode:=true
 ```
 
-起動するノード：yolox_object_detection / object_tracking / people_tracking / people_recognition / contact_detection /（save_image 時のみ）shigure_api
+起動するノード：yolox_object_detection / object_tracking / people_tracking / people_recognition / contact_detection / shigure_api（常駐）
 
-| launch 引数 | 既定 | 効果 |
-| :--- | :--- | :--- |
-| `debug_mode` | false | 全ノードの cv2 デバッグ窓表示＋people_recognition の自動登録ユーザーを .npy/.jpg でディスク保存 |
-| `save_image` | false | 追跡デバッグ画像を `/shigure/tracking_debug_image` へ配信・保存＋Web 表示(shigure_api)を起動 |
-| `enable_profile` | false | 横顔プロフィール特徴を `/profile_feature_add` に配信（横顔学習） |
-| `terminal` | gnome-terminal | 各ノードを開く端末（`gnome-terminal` / `xterm` / `none`）。ヘッドレス環境は `none` |
-| `record` | false | DB 保存系ノード（pose_save / record_event）も起動する（手順6の代わり） |
-| `save_root_path` | (ノード既定) | record_event のイベント画像保存先 |
+フラグ類（`debug_mode` / `enable_profile` / `save_image` / `save_registration`）は**起動時の初期値**で、稼働中は再起動なしに `ros2 param set` で切替可能（[usage.md の「実行中のモード切替」](usage.md#実行中のモード切替長期稼働時のストレージ制御)参照）。
+
+| launch 引数 | 既定 | 効果 | 対応ノードパラメータ |
+| :--- | :--- | :--- | :--- |
+| `debug_mode` | **true** | 全ノードの cv2 デバッグ窓を**表示のみ**（顔データ保存は伴わない）。窓が不要なら `debug_mode:=false` | `is_debug_mode` |
+| `enable_profile` | false | 横顔プロフィール特徴を `/profile_feature_add` に配信（横顔学習） | `enable_profile_insightface` |
+| `save_image` | false | 追跡デバッグ画像を**ローカルディスクに保存**（手元解析用。Web 配信は常時なので無関係） | `save_image` |
+| `save_registration` | false | people_recognition の新規/更新の顔特徴・画像・PCA モデルを .npy/.jpg でディスク保存（`is_debug_mode` とは独立） | `save_registration` |
+| `terminal` | gnome-terminal | 各ノードを開く端末（`gnome-terminal` / `xterm` / `none`）。ヘッドレス環境は `none` |  |
+| `record` | false | DB 保存系ノード（pose_save / record_event）も起動する（手順6の代わり） |  |
+| `save_root_path` | (ノード既定) | record_event のイベント画像保存先 |  |
+
+> 💡 デバッグ窓を見たいだけなら `debug_mode:=true` のみでよい（顔データは保存されない）。顔登録データを溜めたいときだけ `save_registration:=true`。両者は独立に切り替えられる。
 
 ## 6. 記録ノードの起動（別端末・DB へ保存）
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,9 +91,65 @@ docker compose exec db mysql -ushigure -pshigure shigure \
 mysql -h 127.0.0.1 -P 3306 -u shigure -p
 ```
 
-### Web（save_image:=true のとき）
+### Web
 
-`http://<本体PCのIP>:8765` … `/users`(顔画像) / `/ws/tracking_debug`(全体画像) / `/ws/pca_plot`(PCA) / `/ws/events`(認識イベント)
+shigure_api は常駐（`http://<本体PCのIP>:8765`）… `/users`(顔画像) / `/ws/tracking_debug`(全体画像) / `/ws/pca_plot`(PCA) / `/ws/events`(認識イベント)。
+`/ws/tracking_debug` の全体画像(現フレーム)は people_tracking が**常時配信**する（`save_image` とは無関係）。手元ディスクへの画像保存は `save_image` で制御する（下の「実行中のモード切替」参照）。
+
+## 実行中のモード切替（再起動なしで各モードを変更する手順）
+
+各モードは launch 引数（＝起動時の初期値）だけでなく、**稼働中に `ros2 param set` で切り替えられる**。launch し直し不要で、切り替えは即時に反映される。
+
+### 手順（共通）
+
+```sh
+export ROS_DOMAIN_ID=10                                   # 対象ノードと同じドメイン
+
+# 1) 変更する ： ros2 param set <ノード名> <パラメータ名> <true/false>
+ros2 param set /people_tracking_node is_debug_mode true
+
+# 2) 確認する ： 現在値を読む（＋対象ノードのタブに変更ログが出る）
+ros2 param get /people_tracking_node is_debug_mode        # → Boolean value is: True
+```
+
+- `set` した瞬間に反映される（該当ノードのタブに `IsDebugMode : True` 等のログが出る）。
+- **ノード名・パラメータ名は launch 引数名とは別物**。下表の「ノード」「パラメータ名」を使う。
+
+### モード ↔ ノード ↔ パラメータ 対応表
+
+| モード | ノード | パラメータ名 | 既定 | true にすると |
+| :--- | :--- | :--- | :--- | :--- |
+| デバッグ窓表示 | 各ノード（`/people_tracking_node`, `/contact_detection_node`, `/object_tracking_node`, `/yolox_object_detection_node`, `/people_recognition_node`) | `is_debug_mode` | true※ | cv2 デバッグ窓を表示（ディスク保存なし） |
+| 横顔学習の配信 | `/people_tracking_node` | `enable_profile_insightface` | false | 横顔プロフィール特徴を `/profile_feature_add` へ配信 |
+| 追跡画像のローカル保存 | `/people_tracking_node` | `save_image` | false | 追跡デバッグ画像を `debug_images/people_tracking/` に保存（Web 配信は save_image に関係なく常時） |
+| 顔登録の永続化 | `/people_recognition_node` | `save_registration` | false | 新規登録・既存更新の顔特徴/画像/PCA をディスク保存 |
+
+※ `is_debug_mode` の launch 既定は `debug_mode` 引数由来で **true**（ネイティブ launch の既定。窓不要なら `debug_mode:=false`）。個別ノードごとに `ros2 param set` で上書きできる。
+
+### よく使う切り替え例
+
+```sh
+# --- 普段（長期稼働）は保存系を全部 OFF にしておく ---
+ros2 param set /people_recognition_node save_registration          false  # 顔特徴/画像/PCA のディスク保存を停止
+ros2 param set /people_tracking_node    save_image                 false  # 追跡画像のローカル保存を停止（Web配信は継続）
+ros2 param set /people_tracking_node    enable_profile_insightface false  # 横顔特徴の配信を停止
+
+# --- 顔を登録・更新したいときだけ一時的に ON → 済んだら false に戻す ---
+ros2 param set /people_recognition_node save_registration true
+
+# --- 手元で追跡画像を保存したいときだけ ON ---
+ros2 param set /people_tracking_node    save_image true
+
+# --- デバッグ窓を消したい / 出したい（保存とは独立、ディスクは汚さない） ---
+ros2 param set /people_tracking_node    is_debug_mode false  # 骨格・追跡窓を閉じる
+ros2 param set /contact_detection_node  is_debug_mode false  # 持込/持去窓を閉じる
+```
+
+- `save_registration=false` でも**メモリ上の認識・辞書登録は継続**する（止まるのはディスク保存だけ。再起動でメモリ辞書は消える）。
+- `is_debug_mode`（デバッグ窓表示）と `save_registration`（顔データ保存）は**独立**。窓を見たいだけならディスクは一切汚れない。
+- ⚠️ **PCAプロット(`/ws/pca_plot`)・顔サムネイル(`/users`)への影響**：これらは登録済み特徴を `face_models/user_*/*.npy`（と `.jpg`）から読む。`save_registration=false` の間は**新規に自動登録されたユーザーがプロット/サムネイルに反映されない**（基底の再学習も止まる）。事前登録済みユーザーの参照点と、現フレームのライブ点（`/feature_info` 由来、保存不要）は表示され続ける。新規登録を反映して確認したいときは `save_registration=true` にする。
+- shigure_api（Web）は常駐。追跡デバッグ画像(現フレーム)は **`save_image` に関係なく常時配信**されるので、WebUI はいつでも現フレームを表示できる。`save_image=true` のときだけ、その画像を**ローカルディスクにも保存**する（`debug_images/people_tracking/` に累積。手元解析用）。
+- 上記 param 名は launch 引数名ではなく**ノードのパラメータ名**（`enable_profile` → `enable_profile_insightface`、`debug_mode` → `is_debug_mode`。`save_image` / `save_registration` は引数名＝param 名）。
 
 ## 調整パラメータ
 
@@ -104,7 +160,7 @@ ros2 param set /people_tracking_node face_name_score_threshold 2.0
 
 - 自動登録（未登録者を `user_newN` として辞書追加）の発火特徴数：`node_people_recognition.py` の `MIN_FEATURES_FOR_NEW_USER`（既定20）
 - 顔検出頻度を上げたい：同ファイルの `MIN_DET_SCORE`（既定0.8）を下げる
-- 自動登録ユーザーの**ディスク保存は `debug_mode:=true`（is_debug_mode=True）時のみ**。false だとメモリ辞書のみで再起動で消える
+- 自動登録ユーザーの**ディスク保存は `save_registration:=true`（param `save_registration`）時のみ**（デバッグ窓の `debug_mode` とは独立）。false だとメモリ辞書のみで再起動で消える
 
 ## トラブルシュート
 

--- a/shigure_core/shigure_core/launch/shigure_core_launch.py
+++ b/shigure_core/shigure_core/launch/shigure_core_launch.py
@@ -1,21 +1,33 @@
 """YOLO11 + 顔認識パイプライン（既定 launch）。
 
-launch 引数:
-  debug_mode:=true/false    全ノードの is_debug_mode を制御（既定 false）。
-                            true で各ノードの cv2 デバッグ窓を表示し、
-                            people_recognition は自動登録ユーザーの .npy/.jpg をディスク保存する。
-  save_image:=true/false    true で people_tracking が追跡デバッグ画像を
-                            /shigure/tracking_debug_image へ配信・保存し、Web表示(shigure_api)を起動（既定 false）。
+launch 引数（フラグ類は「起動時の初期値」。稼働中は ros2 param set で切替可能）:
+  debug_mode:=true/false    全ノードの is_debug_mode を制御（既定 true）。
+                            true で各ノードの cv2 デバッグ窓を表示する（表示のみ。
+                            顔データのディスク保存は save_registration で別管理）。
   enable_profile:=true/false true で横顔プロフィール特徴を /profile_feature_add に配信（既定 false）。
+  save_image:=true/false    true で追跡デバッグ画像を people_tracking がローカルディスクに保存する
+                            （手元解析用。既定 false）。Web配信は常時なので save_image とは無関係。
+  save_registration:=true/false true で people_recognition が新規/更新の顔特徴・画像・
+                            PCAモデルをディスク保存する（既定 false。is_debug_mode とは独立）。
   terminal:=gnome-terminal/xterm/none
                             各ノードを開く端末エミュレータ（既定 gnome-terminal）。
                             Docker では xterm、ヘッドレス環境では none を指定する。
   record:=true/false        true で DB 保存系ノード（pose_save / record_event）も起動する（既定 false）。
   save_root_path:=<path>    record_event のイベント画像保存先（既定はノード側のデフォルト値）。
 
+  ※ shigure_api（Web表示）は常時起動する。追跡デバッグ画像(現フレーム)は people_tracking が
+    save_image に関係なく常に /shigure/tracking_debug_image へ配信する。save_image はこの画像を
+    ローカルディスクにも保存するかどうかだけを制御する。
+
+実行中の切替（再起動不要）:
+  ros2 param set /people_recognition_node save_registration false  # 顔データのディスク保存を停止
+  ros2 param set /people_tracking_node    save_image        false  # 追跡画像のローカル保存を停止（Web配信は継続）
+  ros2 param set /people_tracking_node    enable_profile_insightface false  # 横顔特徴の配信を停止
+  ros2 param set /people_tracking_node    is_debug_mode     true   # デバッグ窓の表示（保存はしない）
+
 例:
   ros2 launch shigure_core shigure_core_launch.py
-  ros2 launch shigure_core shigure_core_launch.py debug_mode:=true save_image:=true
+  ros2 launch shigure_core shigure_core_launch.py debug_mode:=true save_registration:=true
   ros2 launch shigure_core shigure_core_launch.py terminal:=xterm record:=true  # Docker と同等の構成
 """
 
@@ -41,8 +53,9 @@ def _make_prefix(terminal: str, title: str) -> str:
 def _setup_nodes(context):
     """launch引数を解決してノード一覧を構築します."""
     debug_mode = _to_bool(context.launch_configurations['debug_mode'])
-    save_image = _to_bool(context.launch_configurations['save_image'])
     enable_profile = _to_bool(context.launch_configurations['enable_profile'])
+    save_image = _to_bool(context.launch_configurations['save_image'])
+    save_registration = _to_bool(context.launch_configurations['save_registration'])
     record = _to_bool(context.launch_configurations['record'])
     terminal = context.launch_configurations['terminal']
     save_root_path = context.launch_configurations['save_root_path']
@@ -68,14 +81,17 @@ def _setup_nodes(context):
             {'enable_profile_insightface': enable_profile},
         ]),
         # 顔認識（/face_recognition/results, /feature_info, /dictionary_update を配信）
-        # is_debug_mode=true のとき自動登録ユーザーの特徴/画像をディスク保存する。
-        make_node('people_recognition', parameters=[is_debug]),
+        # is_debug_mode は表示用。顔特徴/画像のディスク保存は save_registration で制御する。
+        make_node('people_recognition', parameters=[
+            is_debug,
+            {'save_registration': save_registration},
+        ]),
         make_node('contact_detection', parameters=[is_debug]),
     ]
 
-    # Web API（save_image:=true のときのみ起動）
-    if save_image:
-        nodes.append(make_node('shigure_api', package='shigure_api'))
+    # Web API（常駐）。people_tracking が /shigure/tracking_debug_image を常時配信するので、
+    # WebUI ではいつでも現フレームの追跡画像を確認できる。サーバ自体はストレージを消費しない。
+    nodes.append(make_node('shigure_api', package='shigure_api'))
 
     # DB 保存系（record:=true のときのみ起動）
     if record:
@@ -93,18 +109,26 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument(
             'debug_mode',
-            default_value='false',
-            description='true のとき全ノードの is_debug_mode を有効化（cv2デバッグ窓表示・顔データのディスク保存）。',
-        ),
-        DeclareLaunchArgument(
-            'save_image',
-            default_value='false',
-            description='true のとき追跡デバッグ画像を保存・配信し、Web表示(shigure_api)を起動する。',
+            default_value='true',
+            description='true のとき全ノードの is_debug_mode を有効化（cv2デバッグ窓の表示のみ。'
+                        '顔データのディスク保存は save_registration で別管理）。',
         ),
         DeclareLaunchArgument(
             'enable_profile',
             default_value='false',
             description='true のとき横顔プロフィール特徴を /profile_feature_add に配信する（横顔学習）。',
+        ),
+        DeclareLaunchArgument(
+            'save_image',
+            default_value='false',
+            description='true のとき追跡デバッグ画像を people_tracking がローカルディスクに保存する'
+                        '（手元解析用。Web配信は常時なので save_image とは無関係）。',
+        ),
+        DeclareLaunchArgument(
+            'save_registration',
+            default_value='false',
+            description='true のとき people_recognition が新規/更新の顔特徴・画像・PCAモデルを'
+                        'ディスクへ保存する（is_debug_mode とは独立）。',
         ),
         DeclareLaunchArgument(
             'terminal',

--- a/shigure_core/shigure_core/nodes/node_people_recognition.py
+++ b/shigure_core/shigure_core/nodes/node_people_recognition.py
@@ -1,8 +1,11 @@
+from typing import List
+
 import cv2
 import message_filters
 import numpy as np
 import rclpy
 from rclpy.qos import QoSProfile, ReliabilityPolicy
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType, SetParametersResult, Parameter
 from sensor_msgs.msg import CompressedImage
 from shigure_core_msgs.msg import FaceRecognitionResult, FaceInfo, RecognitionHistory, DictionaryUpdate, FeatureInfo, ProfileFeatureAdd
 
@@ -54,6 +57,20 @@ class PeopleRecognitionNode(ImagePreviewNode):
         self.all_images = {}
         self.last_recognition_history = None  # 最後に受信したrecognition_history
 
+        # 顔登録データ(.npy/.jpg/pca_model)をディスクへ永続化するか。
+        # デバッグ窓表示用の is_debug_mode とは独立させる（表示だけしたい/保存だけしたいを分離）。
+        # 長期稼働のストレージ節約のため既定 false。実行中に切替可:
+        #   ros2 param set /people_recognition_node save_registration true
+        save_registration_descriptor = ParameterDescriptor(
+            type=ParameterType.PARAMETER_BOOL,
+            description='true のとき新規/更新した顔特徴・画像・PCAモデルをディスクへ保存する。')
+        self.declare_parameter('save_registration', False, save_registration_descriptor)
+        self.save_registration: bool = \
+            self.get_parameter('save_registration').get_parameter_value().bool_value
+        # 基底クラスの _on_set_parameters は上書きせず、専用コールバックを追加登録する。
+        self.add_on_set_parameters_callback(self._on_set_parameters_people_recognition)
+        self.get_logger().info('SaveRegistration : ' + str(self.save_registration))
+
         # QoS Settings
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
 
@@ -104,9 +121,17 @@ class PeopleRecognitionNode(ImagePreviewNode):
         # people_idとuser_idの対応付け用辞書
         self.user_id_map = {}
 
+    def _on_set_parameters_people_recognition(self, params: List[Parameter]) -> SetParametersResult:
+        """save_registration の実行時変更を反映する（他パラメータは基底コールバックが処理）。"""
+        for param in params:
+            if param.name == 'save_registration':
+                self.save_registration = param.value
+                self.get_logger().info('SaveRegistration : ' + str(self.save_registration))
+        return SetParametersResult(successful=True)
+
     def rebuild_pca_model_on_disk(self) -> None:
         """Rebuild pca_model.pkl from face_models (after new user saved to disk)."""
-        if not self.is_debug_mode:
+        if not self.save_registration:
             return
         result = build_pca_model(Path(DIRECTORY), Path(DIRECTORY) / 'pca_model.pkl')
         if result.success:
@@ -131,7 +156,7 @@ class PeopleRecognitionNode(ImagePreviewNode):
             f'total={len(self.profile_dictionary[user_name])}'
         )
 
-        if not self.is_debug_mode:
+        if not self.save_registration:
             return
 
         profile_dir = os.path.join(DIRECTORY, user_name, 'profile')
@@ -386,7 +411,7 @@ class PeopleRecognitionNode(ImagePreviewNode):
         self._ensure_profile_user_entry(user_name)
 
         user_dir = None
-        if self.is_debug_mode:
+        if self.save_registration:
             # 新しいディレクトリを作成
             user_dir = os.path.join(DIRECTORY, user_name)
             os.makedirs(user_dir, exist_ok=True)
@@ -398,7 +423,7 @@ class PeopleRecognitionNode(ImagePreviewNode):
                 continue
             feature = self.all_features[num]["feature"]
             self.dictionary[user_name].append(feature)
-            if self.is_debug_mode and user_dir is not None:
+            if self.save_registration and user_dir is not None:
                 # 保存処理
                 feature_path = os.path.join(user_dir, f"{user_name}_{num}.npy")
                 np.save(feature_path, feature)

--- a/shigure_core/shigure_core/nodes/node_people_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_people_tracking.py
@@ -51,15 +51,16 @@ class PeopleTrackingNode(ImagePreviewNode):
         self._prev_tracked_people_ids = set()   # 直前フレームの追跡ID（消えたIDのクリーンアップ用）
         self._profile_last_save_frame = {}      # {people_id: 最後に横顔保存したframe_count}
 
-        # 画像保存モード。true のとき追跡デバッグ画像を /shigure/tracking_debug_image に配信し、
-        # ローカルにも保存する（Web表示はこのモードでのみ利用可能）。launch の save_image 引数で切替。
+        # ローカル画像保存モード。true のとき追跡デバッグ画像をローカルディスクに保存する
+        # （手元で解析したい人向け）。shigure_api への配信(/shigure/tracking_debug_image)は
+        # このフラグとは無関係に常時行う。launch の save_image 引数で切替。
         self.declare_parameter('save_image', False,
                                ParameterDescriptor(type=ParameterType.PARAMETER_BOOL,
-                                                   description='true のとき追跡デバッグ画像を配信・保存する（Web表示用）。'))
+                                                   description='true のとき追跡デバッグ画像をローカルディスクに保存する（Web配信は常時）。'))
         self.save_image: bool = self.get_parameter('save_image').get_parameter_value().bool_value
 
         # 横顔プロフィール学習。true のとき確定人物の@profile顔特徴を /profile_feature_add へ配信する。
-        # 有効化には color 画像が必要なため、購読条件(is_debug_mode/save_image)にも含める。
+        # 有効化には color 画像が必要なため、購読条件(is_debug_mode/enable_profile_insightface)にも含める。
         self.declare_parameter('enable_profile_insightface', False,
                                ParameterDescriptor(type=ParameterType.PARAMETER_BOOL,
                                                    description='true のとき横顔プロフィール特徴を /profile_feature_add に配信する。'))
@@ -87,7 +88,7 @@ class PeopleTrackingNode(ImagePreviewNode):
             self.face_recognition_callback,
             10
         )
-        # 追跡デバッグ画像(オーバーレイ)の配信先。save_image モード時のみ実際に配信する。
+        # 追跡デバッグ画像(オーバーレイ)の配信先。5フレーム毎に現フレームを配信する（shigure_api のWeb表示用）。
         self._debug_image_publisher = self.create_publisher(
             DebugImage,
             '/shigure/tracking_debug_image',
@@ -125,21 +126,19 @@ class PeopleTrackingNode(ImagePreviewNode):
             qos_profile=shigure_qos
         )
 
-        # color 画像が必要なのは、描画(is_debug_mode)・画像保存(save_image)・横顔保存(enable_profile_insightface)のいずれか。
-        if not self.is_debug_mode and not self.save_image and not self.enable_profile_insightface:
-            self.time_synchronizer = message_filters.TimeSynchronizer(
-                [depth_subscriber, key_points_subscriber, depth_camera_info_subscriber], 30000)
-            self.time_synchronizer.registerCallback(self.callback)
-        else:
-            color_subscriber = message_filters.Subscriber(
-                self,
-                CompressedImage,
-                '/rs/color/compressed',
-                qos_profile=shigure_qos
-            )
-            self.time_synchronizer = message_filters.TimeSynchronizer(
-                [depth_subscriber, key_points_subscriber, depth_camera_info_subscriber, color_subscriber], 400000)
-            self.time_synchronizer.registerCallback(self.callback_debug)
+        # color 画像は Web配信(5フレーム毎)・描画(is_debug_mode)・横顔保存(enable_profile_insightface)
+        # で必要になる。Web配信は常時行うため、常に color を購読して callback_debug を使う。
+        # （color/depth/cameraInfo は同一 RealSense 由来でタイムスタンプが揃うため 4 topic
+        # 同期でも取りこぼしは増えない。color 不要なフレームは callback_debug 側で復号しない。）
+        color_subscriber = message_filters.Subscriber(
+            self,
+            CompressedImage,
+            '/rs/color/compressed',
+            qos_profile=shigure_qos
+        )
+        self.time_synchronizer = message_filters.TimeSynchronizer(
+            [depth_subscriber, key_points_subscriber, depth_camera_info_subscriber, color_subscriber], 400000)
+        self.time_synchronizer.registerCallback(self.callback_debug)
 
         # ros params
         self.declare_parameter('threshold_distance', 1000,
@@ -190,12 +189,10 @@ class PeopleTrackingNode(ImagePreviewNode):
                 self.face_name_score_threshold = param.value
                 self.get_logger().info('FaceNameScoreThreshold : ' + str(self.face_name_score_threshold))
             elif param.name == 'save_image':
-                # 実行中の切替も反映するが、color購読は起動時に決まるため、保存/配信を実際に
-                # 行えるのは起動時から is_debug_mode か save_image が有効だった場合に限る。
+                # ローカルディスク保存の有無のみを制御する（Web配信は常時で影響しない）。
                 self.save_image = param.value
                 self.get_logger().info('SaveImage : ' + str(self.save_image))
             elif param.name == 'enable_profile_insightface':
-                # color購読は起動時に決まるため、起動時から有効だった場合のみ実際に横顔保存できる。
                 self.enable_profile_insightface = param.value
                 self.get_logger().info('EnableProfileInsightface : ' + str(self.enable_profile_insightface))
         return SetParametersResult(successful=True)
@@ -424,15 +421,24 @@ class PeopleTrackingNode(ImagePreviewNode):
                        camera_info: CameraInfo, color_src: CompressedImage):
         published_msg: ShigurePoseKeyPointsList = self.callback(depth_src, key_points_list, camera_info)
 
+        # 現フレームを shigure_api(/ws/tracking_debug)へ配信するフレームか（負荷軽減のため5フレーム毎）。
+        # WebUI は常駐なので配信は常時行う。save_image=true のときは同じ画像をローカル保存もする。
+        publish_web = (self.frame_count % 5 == 0)
+
+        # color 画像が要るのは Web配信 / デバッグ窓表示 / 横顔保存 のいずれか。
+        # どれも不要なフレームは復号せずに抜ける（CPU節約）。people_detection は上の callback で配信済み。
+        # （destroyAllWindows は waitKey と同じトピックコールバックスレッドから呼ぶ必要がある。）
+        if not publish_web and not self.is_debug_mode and not self.enable_profile_insightface:
+            return
+
         color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_src)
 
         # 横顔プロフィール保存（描画前の生画像から切り出すため、_draw_overlay より先に行う）
         if self.enable_profile_insightface:
             self._process_profile_save(published_msg, color_img)
 
-        # デバッグ表示も画像保存も不要なら描画はしない（ウィンドウは閉じる）
-        if not self.is_debug_mode and not self.save_image:
-            cv2.destroyAllWindows()
+        # オーバーレイ描画が要るのは Web配信フレーム または デバッグ窓表示のとき。
+        if not publish_web and not self.is_debug_mode:
             return
 
         self._draw_overlay(color_img, published_msg)
@@ -446,10 +452,12 @@ class PeopleTrackingNode(ImagePreviewNode):
         else:
             cv2.destroyAllWindows()
 
-        # 画像保存モード: 追跡デバッグ画像を配信・保存する（Web表示用）。負荷軽減のため5フレーム毎。
-        if self.save_image and self.frame_count % 5 == 0:
+        # WebUI(shigure_api /ws/tracking_debug)へ現フレームのオーバーレイ画像を常時配信する。
+        # save_image=true のときのみ、同じ画像をローカルディスクにも保存する（手元解析用）。
+        if publish_web:
             self._publish_tracking_debug_image(color_img)
-            self._save_tracking_debug_image(color_img)
+            if self.save_image:
+                self._save_tracking_debug_image(color_img)
 
     def _draw_overlay(self, color_img: np.ndarray, published_msg: ShigurePoseKeyPointsList) -> None:
         """追跡結果(バウンディングボックスとID/顔名ラベル)を color_img へ描画する."""
@@ -498,7 +506,7 @@ class PeopleTrackingNode(ImagePreviewNode):
         self._debug_image_publisher.publish(msg)
 
     def _save_tracking_debug_image(self, color_img: np.ndarray) -> None:
-        """オーバーレイ画像をローカルの debug_images ディレクトリへ保存する."""
+        """オーバーレイ画像をローカルの debug_images ディレクトリへ保存する（save_image=true 時のみ）."""
         if not hasattr(self, '_debug_image_dir'):
             # shigure_core パッケージ直下の debug_images/people_tracking を保存先とする。
             base = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'debug_images')


### PR DESCRIPTION
プロセス実行中のオプションモード切り替えの実装
・DEBUG_MODE(default True) デバッグ窓の表示
・SAVE_IMAGE(default False)  追跡デバッグ画像をローカルディスクに保存
・ENABLE_PROFILE(default False) 横顔プロフィール特徴の配信・学習
・SAVE_REGISTRATION(default False) 動登録ユーザーの顔特徴・画像・PCAモデルのディスク保存
ros set paramで変更可能
使用方法を追記

Fast APIから現フレーム画像送信を永続化(WebUI用)
