### PR TITLE
接触イベントの2D bboxをDBに保存し、GET /contacts で照会可能にする

### DIFF
--- a/shigure_api/shigure_api/app.py
+++ b/shigure_api/shigure_api/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import queue
 from contextlib import asynccontextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import AsyncIterator, List, Set
 
@@ -13,7 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 
 from shigure_api.config import API_KEY, FACE_MODELS_DIR, PCA_REDRAW_EVERY, PCA_TRAJECTORY_MAX_POINTS, default_pca_model_path
-from shigure_api.events import UserEvent, UserSummary, user_event_to_dict
+from shigure_api.events import ContactCandidate, UserEvent, UserSummary, contact_row_to_model, user_event_to_dict
 from shigure_api.feature_images import find_face_image_path, load_face_thumbnail
 from shigure_api.pca_plot import PcaPlotHub, PcaPlotStateBuilder
 from shigure_api.tracking_debug import TrackingDebugHub
@@ -169,6 +170,31 @@ def create_app() -> FastAPI:
     ) -> dict:
         _verify_api_key(x_api_key)
         return {'events': hub.recent_events(limit=limit)}
+
+    @app.get('/contacts', response_model=List[ContactCandidate])
+    def list_contacts(
+        date_from: datetime = Query(alias='from', description='時間窓の開始 (ISO8601)'),
+        date_to: datetime = Query(alias='to', description='時間窓の終了 (ISO8601)'),
+        action: str | None = Query(default=None, description='bring_in / take_out で絞り込む'),
+        x_api_key: str | None = Header(default=None, alias='X-API-Key'),
+    ) -> List[ContactCandidate]:
+        """指定時間窓の接触イベントを人物名・2D bbox付きで返す。
+
+        object_search_system が「時刻+bbox」で SAM2 物体に人物を帰属させるための照会口。
+        IoU 判定は呼び出し側の責務なので、ここでは候補を絞らず時間窓で返すだけにする。
+        """
+        _verify_api_key(x_api_key)
+        if date_from > date_to:
+            raise HTTPException(status_code=400, detail='from must be earlier than to')
+        try:
+            # shigure_core / mysql-connector を import 時点で要求しないよう遅延 import する
+            from shigure_core.db.event_repository import EventRepository
+
+            rows = EventRepository.select_contacts(date_from, date_to, action)
+        except Exception as exc:
+            # DB 断でも API 全体は落とさない（顔認識イベント配信は継続させる）
+            raise HTTPException(status_code=503, detail=f'DB query failed: {exc}') from exc
+        return [contact_row_to_model(row) for row in rows]
 
     @app.get('/api/users/{user_id}/features/{feature_num}/face')
     def get_feature_face(

--- a/shigure_api/shigure_api/events.py
+++ b/shigure_api/shigure_api/events.py
@@ -30,6 +30,51 @@ class UserSummary(BaseModel):
     profile_feature_count: int = 0
 
 
+class ContactCandidate(BaseModel):
+    """接触イベント1件。object_search_system が時刻+bboxで突き合わせる候補。
+
+    bbox は [x, y, width, height]（左上原点、shigure のカメラ解像度基準）。
+    bbox 列は migration 9/10 以降にのみ入るため、それ以前の行では None になる。
+    """
+
+    shigure_event_id: str
+    action: str
+    created_at: str
+    person_id: Optional[str] = None
+    face_name: Optional[str] = None
+    object_id: Optional[str] = None
+    people_bbox: Optional[list[float]] = None
+    object_bbox: Optional[list[float]] = None
+
+
+def _bbox_or_none(x, y, w, h) -> Optional[list[float]]:
+    """4値が揃っている場合のみ [x, y, w, h] を返す。1つでも NULL なら None。"""
+    if x is None or y is None or w is None or h is None:
+        return None
+    return [float(x), float(y), float(w), float(h)]
+
+
+def contact_row_to_model(row: Dict[str, Any]) -> ContactCandidate:
+    """EventRepository.select_contacts の1行を API レスポンスに変換する。"""
+    created_at = row.get('created_at')
+    return ContactCandidate(
+        shigure_event_id=str(row.get('shigure_event_id')),
+        action=str(row.get('action')),
+        created_at=created_at.isoformat() if created_at is not None else '',
+        person_id=row.get('person_id'),
+        face_name=row.get('face_name'),
+        object_id=row.get('object_id'),
+        people_bbox=_bbox_or_none(
+            row.get('people_bbox_x'), row.get('people_bbox_y'),
+            row.get('people_bbox_width'), row.get('people_bbox_height'),
+        ),
+        object_bbox=_bbox_or_none(
+            row.get('object_bbox_x'), row.get('object_bbox_y'),
+            row.get('object_bbox_width'), row.get('object_bbox_height'),
+        ),
+    )
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 

--- a/shigure_core/resource/db/migration/10_add_bbox_to_object.down.sql
+++ b/shigure_core/resource/db/migration/10_add_bbox_to_object.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `object`
+  DROP COLUMN `bbox_height`,
+  DROP COLUMN `bbox_width`,
+  DROP COLUMN `bbox_y`,
+  DROP COLUMN `bbox_x`;

--- a/shigure_core/resource/db/migration/10_add_bbox_to_object.up.sql
+++ b/shigure_core/resource/db/migration/10_add_bbox_to_object.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `object`
+  ADD COLUMN `bbox_x` FLOAT NULL DEFAULT NULL AFTER `depth`,
+  ADD COLUMN `bbox_y` FLOAT NULL DEFAULT NULL AFTER `bbox_x`,
+  ADD COLUMN `bbox_width` FLOAT NULL DEFAULT NULL AFTER `bbox_y`,
+  ADD COLUMN `bbox_height` FLOAT NULL DEFAULT NULL AFTER `bbox_width`;

--- a/shigure_core/resource/db/migration/9_add_bbox_to_people.down.sql
+++ b/shigure_core/resource/db/migration/9_add_bbox_to_people.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `people`
+  DROP COLUMN `bbox_y`,
+  DROP COLUMN `bbox_x`;

--- a/shigure_core/resource/db/migration/9_add_bbox_to_people.up.sql
+++ b/shigure_core/resource/db/migration/9_add_bbox_to_people.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `people`
+  ADD COLUMN `bbox_x` FLOAT NULL DEFAULT NULL AFTER `icon_height`,
+  ADD COLUMN `bbox_y` FLOAT NULL DEFAULT NULL AFTER `bbox_x`;

--- a/shigure_core/shigure_core/db/event_repository.py
+++ b/shigure_core/shigure_core/db/event_repository.py
@@ -130,6 +130,44 @@ class EventRepository:
         return pose_id
 
     @staticmethod
+    def select_contacts(date_from, date_to, action: str = None):
+        """指定時間窓の接触イベントを、人物名と2D bbox付きで返す。
+
+        object_search_system が「時刻+bbox」でSAM2物体と人物を突き合わせるための照会用。
+        IoU判定は呼び出し側で行うため、ここでは候補を返すだけにする。
+        人物bboxの幅・高さは icon_width/icon_height を流用している（insert_people 参照）。
+        """
+        ctx = mysql.connector.connect(**config)
+        cur = ctx.cursor(dictionary=True)
+
+        sql = (
+            "SELECT e.id AS shigure_event_id, e.action, e.created_at, "
+            "p.person_id, p.name AS face_name, "
+            "p.bbox_x AS people_bbox_x, p.bbox_y AS people_bbox_y, "
+            "p.icon_width AS people_bbox_width, p.icon_height AS people_bbox_height, "
+            "o.object_id, "
+            "o.bbox_x AS object_bbox_x, o.bbox_y AS object_bbox_y, "
+            "o.bbox_width AS object_bbox_width, o.bbox_height AS object_bbox_height "
+            "FROM event e "
+            "JOIN people p ON e.people_id = p.id "
+            "JOIN object o ON e.object_id = o.id "
+            "WHERE e.created_at >= %s AND e.created_at <= %s"
+        )
+        params = [date_from, date_to]
+
+        if action:
+            sql += " AND e.action = %s"
+            params.append(action)
+
+        sql += " ORDER BY e.created_at ASC"
+
+        cur.execute(sql, tuple(params))
+        rows = cur.fetchall()
+        ctx.close()
+
+        return rows
+
+    @staticmethod
     def select_with_count(page: int):
         ctx = mysql.connector.connect(**config)
         cur = ctx.cursor()

--- a/shigure_core/shigure_core/db/event_repository.py
+++ b/shigure_core/shigure_core/db/event_repository.py
@@ -7,20 +7,28 @@ from shigure_core.db.convert_format import ConvertMsg
 class EventRepository:
 
     @staticmethod
-    def insert_people(person_id: str, name: str, icon_path: str, icon_width: int, icon_height: int):
+    def insert_people(person_id: str, name: str, icon_path: str, icon_width: int, icon_height: int,
+                      bbox_x: float = None, bbox_y: float = None):
+        # bbox_x/bbox_y は接触時の人物2D bboxの左上原点。幅・高さは icon_width/icon_height を流用する。
         ctx = mysql.connector.connect(**config)
         cur = ctx.cursor()
-        sql = "INSERT INTO people(person_id, name, icon_path, icon_width, icon_height) VALUES (%s, %s, %s, %s, %s)"
-        cur.execute(sql, (person_id, name, icon_path, icon_width, icon_height))
+        sql = ("INSERT INTO people(person_id, name, icon_path, icon_width, icon_height, bbox_x, bbox_y) "
+               "VALUES (%s, %s, %s, %s, %s, %s, %s)")
+        cur.execute(sql, (person_id, name, icon_path, icon_width, icon_height, bbox_x, bbox_y))
         ctx.commit()
         ctx.close()
 
     @staticmethod
-    def insert_object(object_id: str, icon_path: str, x: float, y: float, z: float, width: float, height: float, depth: float):
+    def insert_object(object_id: str, icon_path: str, x: float, y: float, z: float, width: float, height: float, depth: float,
+                      bbox_x: float = None, bbox_y: float = None, bbox_width: float = None, bbox_height: float = None):
+        # x/y/z/width/height/depth は3次元コライダー。bbox_* は接触時の物体2D bbox（別物なので別カラム）。
         ctx = mysql.connector.connect(**config)
         cur = ctx.cursor()
-        sql = f"INSERT INTO object(object_id, icon_path, x, y, z, width, height, depth) VALUES ('{object_id}', '{icon_path}', '{x}', '{y}', '{z}', '{width}', '{height}', '{depth}')"
-        cur.execute(sql)
+        sql = ("INSERT INTO object(object_id, icon_path, x, y, z, width, height, depth, "
+               "bbox_x, bbox_y, bbox_width, bbox_height) "
+               "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)")
+        cur.execute(sql, (object_id, icon_path, x, y, z, width, height, depth,
+                          bbox_x, bbox_y, bbox_width, bbox_height))
         ctx.commit()
         ctx.close()
 

--- a/shigure_core/shigure_core/nodes/node_record_event.py
+++ b/shigure_core/shigure_core/nodes/node_record_event.py
@@ -141,16 +141,28 @@ class SubtractionAnalysisNode(ImagePreviewNode):
 
                 # db書き込み
                 # ------
-                EventRepository.insert_people(contacted.people_id, contacted.face_name, event_save_path, scene.event.people_bounding_box.width, scene.event.people_bounding_box.height)
+                EventRepository.insert_people(
+                    contacted.people_id,
+                    contacted.face_name,
+                    event_save_path,
+                    scene.event.people_bounding_box.width,
+                    scene.event.people_bounding_box.height,
+                    bbox_x=scene.event.people_bounding_box.x,
+                    bbox_y=scene.event.people_bounding_box.y,
+                )
                 EventRepository.insert_object(
-                    contacted.object_id, 
-                    event_save_path, 
-                    contacted.object_cube.x, 
-                    contacted.object_cube.y, 
-                    contacted.object_cube.z, 
-                    contacted.object_cube.width, 
-                    contacted.object_cube.height, 
-                    contacted.object_cube.depth, 
+                    contacted.object_id,
+                    event_save_path,
+                    contacted.object_cube.x,
+                    contacted.object_cube.y,
+                    contacted.object_cube.z,
+                    contacted.object_cube.width,
+                    contacted.object_cube.height,
+                    contacted.object_cube.depth,
+                    bbox_x=scene.event.object_bounding_box.x,
+                    bbox_y=scene.event.object_bounding_box.y,
+                    bbox_width=scene.event.object_bounding_box.width,
+                    bbox_height=scene.event.object_bounding_box.height,
                 )
 
                 frame_id = str(camera_info.header.frame_id)


### PR DESCRIPTION
## 概要

object_search_system（物体検索システム）との連携に向けて、接触イベントの**2D bbox をDBに永続化**し、**時間窓で照会する API** を追加します。

検索システム側で「誰がこの物体を持ち込んだ/持ち去ったか」を表示できるようにするのが最終目的です。shigure 側は「接触した人物と物体の bbox・時刻」を提供する役割を担い、SAM2 物体との突き合わせ（IoU 判定）は検索システム側が行います。

## 背景

現在、持ち込み/持ち去り判定が2つのシステムで独立しています。

| | shigure_core | object_search_system |
| :--- | :--- | :--- |
| イベント検出 | 接触ベース（手と物体の距離） | SAM2 の追跡状態から導出 |
| 「誰が」 | **持っている**（people_id / face_name） | 持っていない |
| DB | MySQL | PostgreSQL + pgvector |

両者は同じカメラ（`/rs/color/compressed`）を見ているため、**画像座標系が共通**です。そこで「時刻 + 2D bbox」を突き合わせ鍵にして人物を帰属させる方針としました。そのために必要な bbox が、これまでDBに保存されていなかったため本PRで追加します。

（DB・リポジトリの物理統合は行わず、HTTP API で疎結合に連携する方針です。）

## 変更内容

### 1. 2D bbox の永続化

- **migration 9**: `people` に `bbox_x` / `bbox_y` を追加
  - 幅・高さは既存の `icon_width` / `icon_height` を流用（既に人物 bbox の幅高さが入っているため）
- **migration 10**: `object` に `bbox_x` / `bbox_y` / `bbox_width` / `bbox_height` を追加
  - 既存の `x/y/z/width/height/depth` は3次元コライダーのため、2D bbox は別カラムとして追加
- いずれも **NULL 許容**。既存行はそのまま残ります
- `EventRepository.insert_people` / `insert_object` に bbox 引数を追加（デフォルト NULL）
- `record_event` で `Contacted` の `people_bounding_box` / `object_bounding_box` を渡す

### 2. GET /contacts エンドポイント（shigure_api）

```
GET /contacts?from=<ISO8601>&to=<ISO8601>&action=bring_in
```

```json
[{"shigure_event_id":"20260716041007_2","action":"bring_in",
  "created_at":"2026-07-16T04:11:36","person_id":"20260716041007_1",
  "face_name":"user_inoue","object_id":"20260716041007_2",
  "people_bbox":[178,145,219,362],"object_bbox":[434,463,151,163]}]
```

- `EventRepository.select_contacts` で `event` / `people` / `object` を JOIN し、人物名と bbox を返す
- **IoU 判定はサーバに持たせず、時間窓の候補を返すだけ**に留めています（判定ロジックは呼び出し側の責務）
- bbox 列が NULL の行（migration 9/10 以前のイベント）は `people_bbox` / `object_bbox` が `null` で返ります
- 既存の `_verify_api_key` による API キー認証を適用
- `EventRepository` は遅延 import とし、DB 断のときは 503 を返して **API 全体（顔認識イベント配信）は落とさない**

### 3. ついでの修正

- `insert_object` の SQL が f-string 組み立てだったため、規約（`.claude/rules/db.md`）に従いプレースホルダに変更しました

## 動作確認

**実機のDBで確認済みです。** 変更後に稼働させたところ、記録された3件のイベントに bbox が入っていることを確認しました。

```
shigure_event_id | action   | created_at          | face_name  | object_bbox
20260716041007_1 | take_out | 2026-07-16 04:11:19 | user_inoue | [143,476,194,179]
20260716041007_2 | bring_in | 2026-07-16 04:11:36 | user_inoue | [434,463,151,163]
20260716041007_3 | take_out | 2026-07-16 04:11:42 | user_inoue | [434,463,151,163]
```

`bring_in` の時刻 ±5秒で実際に照会し、人物名 + 物体 bbox の候補が1件返ることを確認しました。

また MySQL 8 コンテナと FastAPI TestClient を使い、以下を検証しています（全項目パス）。

- migration 1〜10 が順に適用でき、列が意図通り追加される
- 時間窓での絞り込み / `action` フィルタ / `created_at` 昇順
- **bbox 未設定の古い行が `null` で返る（後方互換）**
- `from` > `to` は 400、該当なしは空配列
- `action` に SQL 片を入れても注入されない

## 注意点

- **bbox 保存開始以前のイベントには遡及できません**（データが存在しないため）。人物帰属が可能なのは本変更の稼働開始以降のイベントのみです
- `shigure_api` は `EventRepository` 経由で `rosidl_runtime_py` に依存します。ROS 環境下で動作するため実害はありませんが、ROS なしでの単体起動はできません