### PR TITLE
feat: 人物名の暫定/確定表示・イベント可視化・顔検出しきい値の改善

### DIFF
--- a/shigure_core/shigure_core/nodes/node_contact_detection.py
+++ b/shigure_core/shigure_core/nodes/node_contact_detection.py
@@ -152,11 +152,14 @@ class ContactDetectionNode(ImagePreviewNode):
             
             #print(action.value)
 
+            # DB/HoloLens へ流す face_name は「確定名」のみ。暫定('?'付き)は保存・送信しない。
+            confirmed_face_name = '' if person.face_name.endswith('?') else person.face_name
+
             if action != ContactActionEnum.TOUCH:
                 contacted = Contacted()
                 contacted.event_id = self._id_manager.new_event_id()
                 contacted.people_id = person.people_id
-                contacted.face_name = person.face_name
+                contacted.face_name = confirmed_face_name
                 contacted.object_id = tracked_object.object_id
                 contacted.action = action.value
                 contacted.people_bounding_box = person.bounding_box
@@ -167,7 +170,7 @@ class ContactDetectionNode(ImagePreviewNode):
                 # TOUCHの場合はevent idを追加せずにpublish
                 contacted = Contacted()
                 contacted.people_id = person.people_id
-                contacted.face_name = person.face_name
+                contacted.face_name = confirmed_face_name
                 contacted.object_id = tracked_object.object_id
                 contacted.action = action.value
                 contacted.people_bounding_box = person.bounding_box
@@ -213,20 +216,21 @@ class ContactDetectionNode(ImagePreviewNode):
                 cv2.circle(color_img, (x, y), 5, (255, 0, 0), thickness=-1)
                 cv2.circle(event_frame, (x, y), 5, (255, 0, 0), thickness=-1)
 
-                # 顔認証で名前が確定していれば名前を併記する(未確定時はface_nameは空文字)
-                people_label = f'ID : {re.sub(".*_", "", person.people_id)}'
-                if person.face_name:
-                    people_label = f'{people_label} ({person.face_name})'
+                # 顔と骨格の結合状態で枠色とラベルを決める（people_tracking と統一）:
+                #   確定('user_xxx')  → 青 ＋ 名前
+                #   暫定('user_xxx?') → 赤 ＋ 名前?
+                #   未結合('')        → 灰 ＋ 'ID : n'
+                p_color, people_label = self.get_person_box_color_label(person)
 
-                cv2.rectangle(color_img, (left, top), (right, bottom), (255, 0, 0), thickness=3)
-                cv2.rectangle(event_frame, (left, top), (right, bottom), (255, 0, 0), thickness=3)
-                text_w, text_h = cv2.getTextSize(people_label, cv2.FONT_HERSHEY_PLAIN, 1.5, 2)[0]
-                cv2.rectangle(color_img, (left, top), (left + text_w, top - text_h), (255, 0, 0), -1)
-                cv2.rectangle(event_frame, (left, top), (left + text_w, top - text_h), (255, 0, 0), -1)
-                cv2.putText(color_img, people_label, (left, top),
-                            cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
-                cv2.putText(event_frame, people_label, (left, top),
-                            cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
+                cv2.rectangle(color_img, (left, top), (right, bottom), p_color, thickness=3)
+                cv2.rectangle(event_frame, (left, top), (right, bottom), p_color, thickness=3)
+                text_w, text_h = cv2.getTextSize(people_label, cv2.FONT_HERSHEY_PLAIN, 2.5, 3)[0]
+                cv2.rectangle(color_img, (left, top - text_h - 6), (left + text_w, top), p_color, -1)
+                cv2.rectangle(event_frame, (left, top - text_h - 6), (left + text_w, top), p_color, -1)
+                cv2.putText(color_img, people_label, (left, top - 4),
+                            cv2.FONT_HERSHEY_PLAIN, 2.5, (255, 255, 255), thickness=3)
+                cv2.putText(event_frame, people_label, (left, top - 4),
+                            cv2.FONT_HERSHEY_PLAIN, 2.5, (255, 255, 255), thickness=3)
                 
 
             # すべての物体領域を書く
@@ -258,7 +262,19 @@ class ContactDetectionNode(ImagePreviewNode):
                         object_image = event_frame[top_expansion : bottom_expansion, left_expansion : right_expansion]
                     else:
                         object_image = event_frame[top : bottom, left : right]
+                    # 拡大表示のサイズ(左上に3倍で貼られる)を控えておく
+                    thumb_h = min(object_image.shape[0] * 3, height)
+                    thumb_w = min(object_image.shape[1] * 3, width)
                     event_frame = self.overlay_image(overlapping_img=object_image, underlying_img=event_frame, shift=(0, 0), resize_scale=(3, 3), is_frame_line=True)
+
+                    # ③ 物体拡大画像の右側に大きな矢印を描画する。
+                    # 右上は時系列キャプション(latest等)を置くので、矢印は少し下げて被りを避ける。
+                    obj_action = ContactActionEnum.value_of(tracked_object.action)
+                    if obj_action is not None:
+                        icon_size = int(np.clip(min(thumb_h, thumb_w) * 0.6, 80, 200))
+                        icx = int(np.clip(thumb_w - icon_size * 0.55, icon_size, width - icon_size // 2 - 5))
+                        icy = int(np.clip(icon_size * 0.5 + 130, 0, max(thumb_h - icon_size * 0.5, icon_size)))
+                        ContactDetectionNode.draw_action_icon(event_frame, obj_action, (icx, icy), size=icon_size)
             print("----------------------")
 
             for hand, object_item in result_list:
@@ -274,13 +290,18 @@ class ContactDetectionNode(ImagePreviewNode):
 
                 color = self.get_color_from_action(action)
 
+                # who: 名前があれば併記（暫定は'?'付きのまま表示）。無ければ体ID。
+                who = person.face_name if person.face_name else f'ID:{re.sub(".*_", "", person.people_id)}'
+
                 # Actionの表示
                 pixel_point = person.point_data[index].pixel_point
                 x = np.clip(int(pixel_point.x), 0, width - 1)
                 y = np.clip(int(pixel_point.y), 0, height - 1)
                 cv2.putText(color_img, f'Action : {action.value}', (x - 40, y - 10), cv2.FONT_HERSHEY_PLAIN, 1.5, color, thickness=2)
-                cv2.rectangle(event_frame, (0, height - 100), (width//4 + 40, height), (0,0,0), -1)
-                cv2.putText(event_frame, f'{action.value}', (20, height - 30), cv2.FONT_HERSHEY_SIMPLEX, 2.5, color, thickness=5)
+                # 右ウィンドウ下部: 下部全幅の黒帯 + 大きな「action : who」（矢印は物体画像の右上に別途描画）
+                cv2.rectangle(event_frame, (0, height - 130), (width, height), (0, 0, 0), -1)
+                cv2.putText(event_frame, f'{action.value} : {who}', (20, height - 40),
+                            cv2.FONT_HERSHEY_SIMPLEX, 2.2, color, thickness=5)
 
             if len(result_list) > 0:
                 cv2.putText(color_img, 'Detected', (0, 10), cv2.FONT_HERSHEY_PLAIN, 1, (0, 0, 255))
@@ -297,11 +318,13 @@ class ContactDetectionNode(ImagePreviewNode):
                 if len(self.event_frame_list) > 4:
                     del self.event_frame_list[-1]
 
+            # 各サムネイル上部に時系列キャプション（current=最新 / oldest=最古の有効枠）を焼く。
+            tiles = self._captioned_event_tiles()
             tile_img = cv2.hconcat([
                 color_img,
                 cv2.vconcat([
-                cv2.hconcat([self.event_frame_list[0], self.event_frame_list[1]]),
-                cv2.hconcat([self.event_frame_list[2], self.event_frame_list[3]])
+                cv2.hconcat([tiles[0], tiles[1]]),
+                cv2.hconcat([tiles[2], tiles[3]])
                 ])
             ])
             cv2.namedWindow('contact_detection', cv2.WINDOW_NORMAL)
@@ -313,6 +336,20 @@ class ContactDetectionNode(ImagePreviewNode):
             print(f'[{datetime.datetime.now()}] fps : {self.fps}', end='\r')
 
     @staticmethod
+    def get_person_box_color_label(person) -> Tuple[Tuple[int, int, int], str]:
+        """
+        人物の顔結合状態から (枠色BGR, ラベル文字列) を返す（people_tracking と統一）.
+
+        確定('user_xxx')→青+名前 / 暫定('user_xxx?')→赤+名前? / 未結合('')→灰+'ID : n'
+        """
+        face_name = person.face_name
+        if not face_name:
+            return (160, 160, 160), f'ID : {re.sub(".*_", "", person.people_id)}'  # 灰
+        if face_name.endswith('?'):
+            return (0, 0, 255), face_name        # 赤：暫定
+        return (255, 0, 0), face_name            # 青：確定
+
+    @staticmethod
     def get_color_from_action(action: ContactActionEnum) -> Tuple[int, int, int]:
         if action == ContactActionEnum.BRING_IN:
             return 128, 255, 255
@@ -321,6 +358,80 @@ class ContactDetectionNode(ImagePreviewNode):
         if action == ContactActionEnum.OBJ_MOVE:
             return 125, 255, 255
         return 255, 128, 255
+
+    def _captioned_event_tiles(self) -> list:
+        """
+        右ウィンドウ用の4枚に時系列キャプションを付けたコピーを返す（④）.
+
+        新しい順に latest / 2nd / 3rd / oldest を、有効(非黒)な枠にだけ大きく焼く。
+        （有効が2枚なら latest,oldest ／3枚なら latest,2nd,oldest 等、両端を latest/oldest にする）
+        未使用（黒）の枠にはキャプションを付けない。元画像は破壊しない。
+        """
+        tiles = [t.copy() for t in self.event_frame_list[:4]]
+        # 有効（黒でない）枠のインデックスを新しい順に集める
+        valid = [i for i, t in enumerate(self.event_frame_list[:4]) if t.any()]
+
+        def caption(idx, text):
+            img = tiles[idx]
+            tw, th = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, 1.5, 3)[0]
+            # 物体ID(左上)と被らないよう、キャプションは各画像の右上に置く。
+            x0 = max(0, img.shape[1] - tw - 24)
+            cv2.rectangle(img, (x0, 0), (img.shape[1], th + 22), (0, 0, 0), -1)
+            cv2.putText(img, text, (x0 + 12, th + 10), cv2.FONT_HERSHEY_SIMPLEX, 1.5,
+                        (0, 255, 255), thickness=3)
+
+        n = len(valid)
+        ordinal = {1: '2nd', 2: '3rd'}       # 中間枠の順位表記（最大4枚なので2nd/3rdのみ）
+        for rank, idx in enumerate(valid):
+            if rank == 0:
+                label = 'latest'
+            elif rank == n - 1:
+                label = 'oldest'
+            else:
+                label = ordinal.get(rank, f'{rank + 1}th')
+            caption(idx, label)
+        return tiles
+
+    @staticmethod
+    def draw_action_icon(img: np.ndarray, action: ContactActionEnum,
+                         center: Tuple[int, int], size: int = 46) -> None:
+        """
+        イベント種別を一目で分かる太い図で描く（③）.
+
+        take_out=上向き矢印(赤) / bring_in=下向き矢印(緑) / obj_move=左右両向き矢印(橙) /
+        touch=丸+中心点(黄)。cv2 の線描画のみでフォント非依存。太さ・矢じりは size に比例。
+        """
+        cx, cy = center
+        h = size // 2
+        w = size // 3
+        th = max(4, size // 8)     # 太さ（サイズに比例。大きいほど太い）
+        tip = max(10, size // 4)   # 矢じりの長さ（サイズに比例）
+
+        def arrow(color, up: bool):
+            # 縦の軸
+            y_tail = cy + h if up else cy - h
+            y_head = cy - h if up else cy + h
+            cv2.line(img, (cx, y_tail), (cx, y_head), color, th, cv2.LINE_AA)
+            # 矢じり
+            dy = -tip if up else tip
+            cv2.line(img, (cx, y_head), (cx - w, y_head - dy), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx, y_head), (cx + w, y_head - dy), color, th, cv2.LINE_AA)
+
+        if action == ContactActionEnum.TAKE_OUT:
+            arrow((0, 0, 255), up=True)          # 上向き・赤（持ち出し）
+        elif action == ContactActionEnum.BRING_IN:
+            arrow((0, 200, 0), up=False)         # 下向き・緑（持ち込み）
+        elif action == ContactActionEnum.OBJ_MOVE:
+            color = (0, 128, 255)                # 橙（移動）：左右両向き
+            cv2.line(img, (cx - h, cy), (cx + h, cy), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx - h, cy), (cx - h + tip, cy - w), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx - h, cy), (cx - h + tip, cy + w), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx + h, cy), (cx + h - tip, cy - w), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx + h, cy), (cx + h - tip, cy + w), color, th, cv2.LINE_AA)
+        else:  # TOUCH
+            color = (0, 255, 255)                # 黄（タッチ）：丸＋中心点
+            cv2.circle(img, (cx, cy), h, color, th, cv2.LINE_AA)
+            cv2.circle(img, (cx, cy), 4, color, thickness=-1)
 
 
 def main(args=None):

--- a/shigure_core/shigure_core/nodes/node_people_recognition.py
+++ b/shigure_core/shigure_core/nodes/node_people_recognition.py
@@ -31,7 +31,7 @@ PROFILE_COSINE_THRESHOLD = 0.4
 NORML2_THRESHOLD = 1.128
 LP_CONFIDENCE_THRESHOLD = 0.7
 FAISS_FALLBACK_MIN_VOTE_RATIO = 0.5
-MIN_DET_SCORE = 0.8
+MIN_DET_SCORE = 0.5  # 顔検出器(det_score)の採用しきい値の既定。param min_det_score で実行中変更可
 # 新規ユーザーとして辞書登録する最低特徴数（この数を超えたら dictionary_renew で登録判定）。
 MIN_FEATURES_FOR_NEW_USER = 20
 
@@ -67,9 +67,20 @@ class PeopleRecognitionNode(ImagePreviewNode):
         self.declare_parameter('save_registration', False, save_registration_descriptor)
         self.save_registration: bool = \
             self.get_parameter('save_registration').get_parameter_value().bool_value
+
+        # 顔検出器(det_score)の採用しきい値。低いほど小さい/遠い顔も拾うが誤検出は増える
+        # （誤検出は照合(COSINE_THRESHOLD)で unknown に落ちるため誤命名リスクは低い）。
+        min_det_score_descriptor = ParameterDescriptor(
+            type=ParameterType.PARAMETER_DOUBLE,
+            description='顔検出器の信頼度(det_score)の採用しきい値。これ未満の顔は照合対象外。')
+        self.declare_parameter('min_det_score', MIN_DET_SCORE, min_det_score_descriptor)
+        self.min_det_score: float = \
+            self.get_parameter('min_det_score').get_parameter_value().double_value
+
         # 基底クラスの _on_set_parameters は上書きせず、専用コールバックを追加登録する。
         self.add_on_set_parameters_callback(self._on_set_parameters_people_recognition)
         self.get_logger().info('SaveRegistration : ' + str(self.save_registration))
+        self.get_logger().info('MinDetScore : ' + str(self.min_det_score))
 
         # QoS Settings
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
@@ -127,6 +138,9 @@ class PeopleRecognitionNode(ImagePreviewNode):
             if param.name == 'save_registration':
                 self.save_registration = param.value
                 self.get_logger().info('SaveRegistration : ' + str(self.save_registration))
+            elif param.name == 'min_det_score':
+                self.min_det_score = param.value
+                self.get_logger().info('MinDetScore : ' + str(self.min_det_score))
         return SetParametersResult(successful=True)
 
     def rebuild_pca_model_on_disk(self) -> None:
@@ -346,8 +360,8 @@ class PeopleRecognitionNode(ImagePreviewNode):
             if x < 20 or y < 20 or x + w > cap_width -20 or y + h > cap_height -20:
                 continue  # 画面外の顔を無視
 
-            # 検出信頼度が低い顔は照合・辞書蓄積の対象外
-            if iface_face.det_score < MIN_DET_SCORE:
+            # 検出信頼度が低い顔は照合・辞書蓄積の対象外（param min_det_score で調整可）
+            if iface_face.det_score < self.min_det_score:
                 continue
 
             face_info = FaceInfo()

--- a/shigure_core/shigure_core/nodes/node_people_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_people_tracking.py
@@ -43,6 +43,7 @@ class PeopleTrackingNode(ImagePreviewNode):
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
 
         # 顔認識結果(体ID→顔ID)の累積履歴。 {people_id: {face_id: {"score", "features_num", "total_features"}}}
+        # 暫定名・確定名ともこの累積のargmaxから決める（案B: latch。get_most_likely_face_id 参照）。
         self.recognition_history = {}
 
         # 横顔プロフィール保存用の状態
@@ -273,6 +274,24 @@ class PeopleTrackingNode(ImagePreviewNode):
         display_id = most_likely_id.replace('@profile', '')
         return display_id, data['score']
 
+    def resolve_face_name(self, people_id):
+        """
+        体IDに対する face_name を決める.
+
+        累積スコアが閾値以上なら確定名（例 'user_nakamura'）を返す。
+        未確定でも現フレームの暫定Top1があれば末尾に '?' を付けた暫定名（例 'user_nakamura?'）を返す。
+        どちらも無ければ空文字を返す。
+        """
+        # 暫定・確定とも累積(recognition_history)のargmaxを使う（案B: latch）。
+        # 累積は追跡が続く限り残るため、顔が見えなくなっても・別人が一瞬映っても、
+        # 累積で勝っている人物の名前が保持され続ける（instantaneousな上書きで消えない）。
+        name, score = self.get_most_likely_face_id(people_id)
+        if name is None or name.startswith('unknown'):
+            return ''
+        if score >= self.face_name_score_threshold:
+            return name          # 確定：?なし
+        return name + '?'        # 暫定：?付き（累積argmaxなのでlatchされる）
+
     def _cleanup_recognition_history(self):
         """現在追跡していない体IDの顔認識履歴・確定名・横顔保存状態を破棄する."""
         current_ids = set(self.tracking_info.get_people_dict().keys())
@@ -408,10 +427,9 @@ class PeopleTrackingNode(ImagePreviewNode):
             _, _, _, openpose_pose_key_points = people
             shigure_pose_key_points = pose_key_points_util.convert_openpose_to_shigure(openpose_pose_key_points,
                                                                                        depth_img, people_id, k)
-            # 顔認識で対応が取れた名前(顔ID)を付与する。しきい値未満は未確定として空のまま。
-            face_name, score = self.get_most_likely_face_id(people_id)
-            if face_name is not None and score >= self.face_name_score_threshold:
-                shigure_pose_key_points.face_name = face_name
+            # 顔認識で対応が取れた名前を付与する。
+            # 確定(累積≥閾値)なら 'user_xxx'、未確定でも暫定Top1があれば 'user_xxx?'、無ければ空。
+            shigure_pose_key_points.face_name = self.resolve_face_name(people_id)
             publish_msg.pose_key_points_list.append(shigure_pose_key_points)
         self._publisher.publish(publish_msg)
 
@@ -482,16 +500,50 @@ class PeopleTrackingNode(ImagePreviewNode):
                 bounding_box.y + bounding_box.height) if bounding_box.y + bounding_box.height < height else height - 1
 
             people_id_num = int(re.sub(".*_", "", people_id))
-            color = self._colors[people_id_num % 255]
-            # 顔認識で名前が確定していれば名前を、無ければ体IDを表示する（オクルージョンによるID変化を吸収）
-            label = pose_key_points.face_name if pose_key_points.face_name else f'ID : {people_id_num}'
+            # face_name の状態で枠色とラベルを決める（ミスリード防止のため色を厳密に固定）:
+            #   確定('user_xxx')   → 青枠(255,0,0)  ＋ 名前
+            #   暫定('user_xxx?')  → 赤枠(0,0,255)  ＋ 名前?
+            #   未認識('')         → 灰枠(160,160,160) ＋ 'ID : n'（体IDの色は使わない）
+            face_name = pose_key_points.face_name
+            if not face_name:
+                color = (160, 160, 160)  # 灰：顔と未結合
+                label = f'ID : {people_id_num}'
+            elif face_name.endswith('?'):
+                color = (0, 0, 255)      # 赤(BGR)：暫定
+                label = face_name
+            else:
+                color = (255, 0, 0)      # 青(BGR)：確定
+                label = face_name
             cv2.circle(color_img, (x, y), 5, color, thickness=-1)
             cv2.rectangle(color_img, (left, top), (right, bottom), color, thickness=3)
             text_w, text_h = cv2.getTextSize(label,
-                                             cv2.FONT_HERSHEY_PLAIN, 1.5, 2)[0]
-            cv2.rectangle(color_img, (left, top), (left + text_w, top - text_h), color, -1)
-            cv2.putText(color_img, label, (left, top),
-                        cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
+                                             cv2.FONT_HERSHEY_PLAIN, 2.5, 3)[0]
+            cv2.rectangle(color_img, (left, top - text_h - 6), (left + text_w, top), color, -1)
+            cv2.putText(color_img, label, (left, top - 4),
+                        cv2.FONT_HERSHEY_PLAIN, 2.5, (255, 255, 255), thickness=3)
+
+        # ① 認識中の顔box（people_recognition の検出結果）を描画する。
+        self._draw_face_boxes(color_img)
+
+    def _draw_face_boxes(self, color_img: np.ndarray) -> None:
+        """現フレームの顔検出box(/face_recognition/results)を描画する（①）."""
+        face_data = getattr(self, 'current_face_data', None)
+        if face_data is None:
+            return
+        height, width = color_img.shape[:2]
+        for face_info in face_data.faces:
+            box = list(face_info.box)
+            if len(box) != 4:
+                continue
+            fx, fy, fw, fh = [int(v) for v in box]
+            left = max(0, fx)
+            top = max(0, fy)
+            right = min(width - 1, fx + fw)
+            bottom = min(height - 1, fy + fh)
+            # 顔ID(faiss最近傍Top1)が実名なら緑、unknownなら灰の細枠。
+            fid = face_info.id.replace('@profile', '')
+            face_color = (128, 128, 128) if fid.startswith('unknown') else (0, 200, 0)
+            cv2.rectangle(color_img, (left, top), (right, bottom), face_color, thickness=2)
 
     def _publish_tracking_debug_image(self, color_img: np.ndarray) -> None:
         """オーバーレイ画像を JPEG エンコードして /shigure/tracking_debug_image に配信する(Web表示用)."""


### PR DESCRIPTION
people_tracking:
- 顔名を「暫定(?付き)→確定」の2段階で付与する resolve_face_name を導入。 暫定・確定とも recognition_history の累積argmaxから決定し、顔が見えなく なっても・別人が一瞬映っても累積で勝つ人物名を保持する(latch)。
- オーバーレイの人物枠色を状態で固定: 未認識=灰/暫定=赤/確定=青。人物ラベルを拡大。
- 認識中の顔box(/face_recognition/results)を描画。

contact_detection:
- 人物枠を people_tracking と同じ 灰/赤/青 に統一(get_person_box_color_label)。
- 右ウィンドウ: 物体拡大画像に大きなイベント矢印(take_out=↑/bring_in=↓/ obj_move=↔/touch=○)を描画。時系列キャプション(latest/2nd/3rd/oldest)を 各画像右上に、イベント名に who(人物名)を併記。
- DB/HoloLens へ流す Contacted.face_name は確定名のみ(暫定'?'は除外)。

people_recognition:
- 顔検出しきい値 MIN_DET_SCORE を 0.8→0.5 に引き下げ、param 'min_det_score' として実行中変更可能にした(小さい/遠い顔の検出率が大幅改善: 2%→85%)。