### PR TITLE
FastAPIに累積スコアを送るエンドポイントを追加、ユーザーが消えた後のPCA図、累積スコア図に対する処理を追加

### DIFF
--- a/shigure_api/shigure_api/app.py
+++ b/shigure_api/shigure_api/app.py
@@ -4,19 +4,38 @@ from __future__ import annotations
 
 import asyncio
 import queue
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncIterator, List, Set
+from typing import AsyncIterator, Dict, List, Set
 
 from fastapi import FastAPI, Header, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 
-from shigure_api.config import API_KEY, FACE_MODELS_DIR, PCA_REDRAW_EVERY, PCA_TRAJECTORY_MAX_POINTS, default_pca_model_path
-from shigure_api.events import UserEvent, UserSummary, user_event_to_dict
+from shigure_api.config import (
+    API_KEY,
+    FACE_MODELS_DIR,
+    PCA_REDRAW_EVERY,
+    PCA_TRAJECTORY_MAX_POINTS,
+    PRESENCE_TICK_SEC,
+    PRESENCE_TIMEOUT_SEC,
+    default_pca_model_path,
+)
+from shigure_api.events import UserEvent, UserSummary, cumulative_scores_to_dict, user_event_to_dict
 from shigure_api.feature_images import find_face_image_path, load_face_thumbnail
 from shigure_api.pca_plot import PcaPlotHub, PcaPlotStateBuilder
 from shigure_api.tracking_debug import TrackingDebugHub
+
+
+class _ScoreUpdate:
+    """累積スコア加算要求（ブロードキャストキュー内でイベントと区別するための内部型）。"""
+
+    __slots__ = ('user_id', 'score')
+
+    def __init__(self, user_id: str, score: float) -> None:
+        self.user_id = user_id
+        self.score = score
 
 
 class EventHub:
@@ -25,35 +44,86 @@ class EventHub:
     def __init__(self) -> None:
         self._clients: Set[WebSocket] = set()
         self._lock = asyncio.Lock()
-        self._thread_queue: queue.Queue[UserEvent] = queue.Queue()
+        self._thread_queue: queue.Queue[object] = queue.Queue()
         self._history: List[UserEvent] = []
         self._history_limit = 100
+        # 今映っているユーザーの累積スコアのみを保持する（退室でエントリごと削除）。
+        self._cumulative_scores: Dict[str, float] = {}
+        # ユーザーごとの最終認識時刻（time.monotonic()）。在室判定に使う。
+        self._last_seen: Dict[str, float] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
 
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
         asyncio.create_task(self._broadcast_loop())
+        asyncio.create_task(self.presence_loop())
 
     def enqueue(self, event: UserEvent) -> None:
         """Thread-safe enqueue from ROS callback thread."""
         self._thread_queue.put_nowait(event)
 
+    def enqueue_score(self, user_id: str, score: float) -> None:
+        """Thread-safe: ユーザーごとの累積スコアに加算する要求を投入する（ROSスレッドから）。"""
+        self._thread_queue.put_nowait(_ScoreUpdate(user_id, float(score)))
+
+    async def handle_score_update(self, update: '_ScoreUpdate') -> List[dict]:
+        if not update.user_id or update.user_id in ('none', 'unknown'):
+            return []
+        total = self._cumulative_scores.get(update.user_id, 0.0) + update.score
+        self._cumulative_scores[update.user_id] = total
+        self._last_seen[update.user_id] = time.monotonic()
+        return [cumulative_scores_to_dict(self._cumulative_scores)]
+
+    async def handle_event(self, event: UserEvent) -> List[dict]:
+        self._history.append(event)
+        if len(self._history) > self._history_limit:
+            self._history = self._history[-self._history_limit:]
+        # 累積スコアの加算は5フレームごとの専用経路で行うため、ここでは現在値を反映するのみ。
+        if event.user_id in self._cumulative_scores:
+            event.cumulative_score = self._cumulative_scores[event.user_id]
+        return [user_event_to_dict(event)]
+
+    def prune_absent(self) -> bool:
+        """在室タイムアウトを超えたユーザーを削除する。削除があれば True。"""
+        now = time.monotonic()
+        expired = [
+            user_id
+            for user_id, seen in self._last_seen.items()
+            if now - seen > PRESENCE_TIMEOUT_SEC
+        ]
+        for user_id in expired:
+            self._cumulative_scores.pop(user_id, None)
+            self._last_seen.pop(user_id, None)
+        return bool(expired)
+
+    async def broadcast(self, payloads: List[dict]) -> None:
+        async with self._lock:
+            dead: List[WebSocket] = []
+            for ws in self._clients:
+                try:
+                    for payload in payloads:
+                        await ws.send_json(payload)
+                except Exception:
+                    dead.append(ws)
+            for ws in dead:
+                self._clients.discard(ws)
+
     async def _broadcast_loop(self) -> None:
         while True:
-            event = await asyncio.to_thread(self._thread_queue.get)
-            self._history.append(event)
-            if len(self._history) > self._history_limit:
-                self._history = self._history[-self._history_limit:]
-            payload = user_event_to_dict(event)
-            async with self._lock:
-                dead: List[WebSocket] = []
-                for ws in self._clients:
-                    try:
-                        await ws.send_json(payload)
-                    except Exception:
-                        dead.append(ws)
-                for ws in dead:
-                    self._clients.discard(ws)
+            item = await asyncio.to_thread(self._thread_queue.get)
+            if isinstance(item, _ScoreUpdate):
+                payloads = await self.handle_score_update(item)
+            else:
+                payloads = await self.handle_event(item)
+            if payloads:
+                await self.broadcast(payloads)
+
+    async def presence_loop(self) -> None:
+        """定期的に退室ユーザーを除去し、変化があれば最新の在室スコアを配信する。"""
+        while True:
+            await asyncio.sleep(PRESENCE_TICK_SEC)
+            if self.prune_absent():
+                await self.broadcast([cumulative_scores_to_dict(self._cumulative_scores)])
 
     async def connect(self, websocket: WebSocket) -> None:
         await websocket.accept()
@@ -61,6 +131,9 @@ class EventHub:
             self._clients.add(websocket)
         for item in self.recent_events(limit=20):
             await websocket.send_json(item)
+        self.prune_absent()
+        if self._cumulative_scores:
+            await websocket.send_json(cumulative_scores_to_dict(self._cumulative_scores))
 
     async def disconnect(self, websocket: WebSocket) -> None:
         async with self._lock:

--- a/shigure_api/shigure_api/config.py
+++ b/shigure_api/shigure_api/config.py
@@ -19,6 +19,13 @@ FACE_MODELS_DIR = _default_face_models_dir()
 
 RECOGNITION_SCORE_THRESHOLD = float(os.environ.get('SHIGURE_RECOGNITION_SCORE_THRESHOLD', '0.4'))
 RECOGNITION_DEBOUNCE_SEC = float(os.environ.get('SHIGURE_RECOGNITION_DEBOUNCE_SEC', '30'))
+# 累積スコアは、閾値以上で認識されたフレームをこの回数数えるごとに1回だけ加算する。
+SCORE_ACCUMULATE_EVERY = int(os.environ.get('SHIGURE_SCORE_ACCUMULATE_EVERY', '5'))
+# 累積スコアは「今映っているユーザー」のみを配信する。最後に認識されてから
+# この秒数を超えたユーザーは退室とみなし、スコアをリセットして配信対象から外す。
+PRESENCE_TIMEOUT_SEC = float(os.environ.get('SHIGURE_PRESENCE_TIMEOUT_SEC', '1'))
+# 退室判定を行う定期チェックの間隔（秒）。
+PRESENCE_TICK_SEC = float(os.environ.get('SHIGURE_PRESENCE_TICK_SEC', '1'))
 
 API_HOST = os.environ.get('SHIGURE_API_HOST', '0.0.0.0')
 API_PORT = int(os.environ.get('SHIGURE_API_PORT', '8765'))

--- a/shigure_api/shigure_api/events.py
+++ b/shigure_api/shigure_api/events.py
@@ -20,6 +20,7 @@ class UserEvent(BaseModel):
     user_id: str
     people_id: Optional[str] = None
     score: Optional[float] = None
+    cumulative_score: Optional[float] = None
     message: str
     timestamp: str = Field(default_factory=lambda: _now_iso())
 
@@ -87,3 +88,12 @@ def event_from_face_recognition(face_id: str, score: float) -> Optional[UserEven
 
 def user_event_to_dict(event: UserEvent) -> Dict[str, Any]:
     return event.model_dump()
+
+
+def cumulative_scores_to_dict(scores: Dict[str, float]) -> Dict[str, Any]:
+    """全ユーザーの累積スコアマップを配信用の辞書に変換する。"""
+    return {
+        'type': 'cumulative_scores',
+        'scores': {user_id: round(value, 4) for user_id, value in scores.items()},
+        'timestamp': _now_iso(),
+    }

--- a/shigure_api/shigure_api/main.py
+++ b/shigure_api/shigure_api/main.py
@@ -44,6 +44,9 @@ def main() -> None:
     def on_tracking_debug(payload: dict) -> None:
         tracking_debug_hub.enqueue(payload)
 
+    def on_score(user_id: str, score: float) -> None:
+        hub.enqueue_score(user_id, score)
+
     ros_thread = threading.Thread(
         target=run_ros_bridge,
         args=(on_event, stop_event),
@@ -51,6 +54,7 @@ def main() -> None:
             'pca_builder': pca_builder,
             'on_pca_payload': on_pca_payload,
             'on_tracking_debug': on_tracking_debug,
+            'on_score': on_score,
         },
         name='shigure_ros_bridge',
         daemon=True,

--- a/shigure_api/shigure_api/pca_plot.py
+++ b/shigure_api/shigure_api/pca_plot.py
@@ -6,6 +6,7 @@ import asyncio
 import pickle
 import queue
 import threading
+import time
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,7 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
 from pydantic import BaseModel
 
+from shigure_api.config import PRESENCE_TIMEOUT_SEC
 from shigure_api.feature_images import feature_num_from_stem
 
 Point2D = Tuple[float, float]
@@ -151,10 +153,17 @@ class PcaPlotStateBuilder:
         *,
         redraw_every: int = 5,
         trajectory_max_points: int = 50,
+        presence_timeout: float = PRESENCE_TIMEOUT_SEC,
     ) -> None:
         self._lock = threading.Lock()
         self._redraw_every = max(1, redraw_every)
         self._trajectory_max_points = max(2, trajectory_max_points)
+        # 今映っているユーザーのみプロットするための在室追跡（user_id -> 最終認識時刻）。
+        self._presence_timeout = max(0.0, presence_timeout)
+        self._present_last_seen: Dict[str, float] = {}
+        # 未確定ユーザー（people_id 単位）の在室追跡と、その people が持つ unlabeled 特徴番号。
+        self._present_people_last_seen: Dict[str, float] = {}
+        self._people_feature_nums: Dict[str, Set[int]] = {}
         self._sequence = 0
         self._feature_counter = 0
         self._face_models_dir = face_models_dir
@@ -248,9 +257,76 @@ class PcaPlotStateBuilder:
         with self._lock:
             self._labeled_new.pop(user_id, None)
 
+    def mark_present(self, user_id: str) -> None:
+        """ユーザーが認識されたことを記録する（在室扱いにする）。認識フレームごとに呼ぶ。"""
+        if not user_id or user_id in ('none', 'unknown'):
+            return
+        with self._lock:
+            self._present_last_seen[user_id] = time.monotonic()
+
+    def present_user_ids_locked(self) -> Set[str]:
+        """在室タイムアウトを超えたユーザーを除去し、今映っている user_id 集合を返す（要ロック済み）。"""
+        now = time.monotonic()
+        expired = [
+            user_id
+            for user_id, seen in self._present_last_seen.items()
+            if now - seen > self._presence_timeout
+        ]
+        for user_id in expired:
+            self._present_last_seen.pop(user_id, None)
+        return set(self._present_last_seen.keys())
+
+    def present_user_ids(self) -> Set[str]:
+        """今映っている user_id 集合を返す（退室分は除去済み）。"""
+        with self._lock:
+            return self.present_user_ids_locked()
+
+    def present_people_ids_locked(self) -> Set[str]:
+        """在室タイムアウトを超えた未確定 people を除去し、今映っている people_id 集合を返す（要ロック済み）。"""
+        now = time.monotonic()
+        expired = [
+            people_id
+            for people_id, seen in self._present_people_last_seen.items()
+            if now - seen > self._presence_timeout
+        ]
+        for people_id in expired:
+            self._present_people_last_seen.pop(people_id, None)
+            self._people_feature_nums.pop(people_id, None)
+        return set(self._present_people_last_seen.keys())
+
+    def present_unlabeled_fns_locked(self) -> Set[int]:
+        """今映っている未確定 people が持つ unlabeled 特徴番号の集合を返す（要ロック済み）。"""
+        present_people = self.present_people_ids_locked()
+        fns: Set[int] = set()
+        for people_id in present_people:
+            fns |= self._people_feature_nums.get(people_id, set())
+        return fns
+
+    def presence_signature(self) -> frozenset:
+        """確定ユーザーと未確定 people を合わせた在室シグネチャ（変化検知用）。"""
+        with self._lock:
+            users = self.present_user_ids_locked()
+            people = self.present_people_ids_locked()
+            return frozenset(users) | frozenset(f'people:{p}' for p in people)
+
     def on_recognition_history(self, msg) -> None:
+        now = time.monotonic()
         with self._lock:
             self._latest_history = msg
+            for user in msg.users:
+                people_id = user.people_id
+                if people_id in self._confirmed_people:
+                    continue
+                fns: Set[int] = set()
+                for face in user.face_info:
+                    if face.id.endswith('@profile'):
+                        continue
+                    if face.id != 'unknown':
+                        continue
+                    fns.update(int(fn) for fn in face.features_num)
+                # 未確定 people を在室として記録し、その unlabeled 特徴番号を更新する。
+                self._present_people_last_seen[people_id] = now
+                self._people_feature_nums[people_id] = fns
 
     def on_dictionary_update(self, people_id: str, name: str) -> Optional[PcaSegmentClosed]:
         if not name or name == 'none':
@@ -258,6 +334,9 @@ class PcaPlotStateBuilder:
         promoted: List[int] = []
         with self._lock:
             self._confirmed_people[people_id] = name
+            # 確定した people は未確定の在室追跡から外す（未確定プロットとしては消す）。
+            self._present_people_last_seen.pop(people_id, None)
+            self._people_feature_nums.pop(people_id, None)
             if self._latest_history is not None:
                 for user in self._latest_history.users:
                     if user.people_id != people_id:
@@ -286,9 +365,11 @@ class PcaPlotStateBuilder:
     def build_unlabeled_update(self) -> PcaUnlabeledUpdate:
         with self._lock:
             self._sequence += 1
+            present_fns = self.present_unlabeled_fns_locked()
             unlabeled = [
                 PcaPlotPoint(feature_num=fn, x=pt[0], y=pt[1])
                 for fn, pt in sorted(self._unlabeled.items())
+                if fn in present_fns
             ]
             return PcaUnlabeledUpdate(
                 timestamp=_now_iso(),
@@ -306,16 +387,25 @@ class PcaPlotStateBuilder:
     def build_state(self) -> PcaPlotState:
         with self._lock:
             self._sequence += 1
+            # 未確定 people の在室（＋その unlabeled 特徴番号）を先に確定させる。
+            present_fns = self.present_unlabeled_fns_locked()
             trajectories = self._build_trajectories_pre_confirm()
             unlabeled = [
                 PcaPlotPoint(feature_num=fn, x=pt[0], y=pt[1])
                 for fn, pt in sorted(self._unlabeled.items())
+                if fn in present_fns
             ]
+            # 今映っているユーザーのプロット（dictionary / labeled_new）だけを含める。
+            present = self.present_user_ids_locked()
             return PcaPlotState(
                 timestamp=_now_iso(),
                 sequence=self._sequence,
-                dictionary={k: list(v) for k, v in self._dictionary.items()},
-                labeled_new={k: list(v) for k, v in self._labeled_new.items()},
+                dictionary={
+                    k: list(v) for k, v in self._dictionary.items() if k in present
+                },
+                labeled_new={
+                    k: list(v) for k, v in self._labeled_new.items() if k in present
+                },
                 unlabeled=unlabeled,
                 trajectories_pre_confirm=trajectories,
             )
@@ -327,6 +417,9 @@ class PcaPlotStateBuilder:
         for user in self._latest_history.users:
             people_id = user.people_id
             if people_id in self._confirmed_people:
+                continue
+            # 退室（在室タイムアウト超過）した未確定 people の軌跡は出さない。
+            if people_id not in self._present_people_last_seen:
                 continue
             feature_nums: List[int] = []
             for face in user.face_info:

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -25,6 +25,7 @@ from shigure_api.config import (
     RECOGNITION_DEBOUNCE_SEC,
     RECOGNITION_HISTORY_TOPIC,
     RECOGNITION_SCORE_THRESHOLD,
+    SCORE_ACCUMULATE_EVERY,
     TRACKING_DEBUG_IMAGE_TOPIC,
 )
 from shigure_api.events import event_from_dictionary_update, event_from_face_recognition
@@ -46,13 +47,16 @@ class RosEventBridge(Node):
         pca_builder: Optional[PcaPlotStateBuilder] = None,
         on_pca_payload: Optional[Callable[[dict], None]] = None,
         on_tracking_debug: Optional[Callable[[dict], None]] = None,
+        on_score: Optional[Callable[[str, float], None]] = None,
     ):
         super().__init__('shigure_api_bridge')
         self._on_event = on_event
         self._pca_builder = pca_builder
         self._on_pca_payload = on_pca_payload
         self._on_tracking_debug = on_tracking_debug
+        self._on_score = on_score
         self._recognition_last_sent: Dict[str, float] = {}
+        self._recognition_frame_count: Dict[str, int] = {}
         self._lock = threading.Lock()
 
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
@@ -123,6 +127,23 @@ class RosEventBridge(Node):
         except Exception as exc:
             self.get_logger().error(f'Failed to emit tracking debug image: {exc}')
 
+    def emit_score(self, user_id: str, score: float) -> None:
+        if self._on_score is None:
+            return
+        try:
+            self._on_score(user_id, score)
+        except Exception as exc:
+            self.get_logger().error(f'Failed to emit score: {exc}')
+
+    def maybe_accumulate_score(self, user_id: str, score: float) -> None:
+        """閾値以上で認識されたフレームを数え、SCORE_ACCUMULATE_EVERY 回ごとに1回だけ加算する。"""
+        if self._on_score is None:
+            return
+        count = self._recognition_frame_count.get(user_id, 0) + 1
+        self._recognition_frame_count[user_id] = count
+        if count % SCORE_ACCUMULATE_EVERY == 0:
+            self.emit_score(user_id, score)
+
     def _on_tracking_debug_image(self, msg: DebugImage) -> None:
         self._emit_tracking_debug(debug_image_msg_to_payload(msg))
 
@@ -171,6 +192,9 @@ class RosEventBridge(Node):
             if event is None:
                 continue
             key = event.user_id
+            # 累積スコアはデバウンスと独立に、5フレームごとに加算する。
+            self.maybe_accumulate_score(key, float(face.score))
+            # フロントへの認識通知は従来どおり30秒デバウンスで間引く。
             with self._lock:
                 last = self._recognition_last_sent.get(key, 0.0)
                 if now - last < RECOGNITION_DEBOUNCE_SEC:
@@ -208,6 +232,7 @@ def run_ros_bridge(
     pca_builder: Optional[PcaPlotStateBuilder] = None,
     on_pca_payload: Optional[Callable[[dict], None]] = None,
     on_tracking_debug: Optional[Callable[[dict], None]] = None,
+    on_score: Optional[Callable[[str, float], None]] = None,
 ) -> None:
     rclpy.init()
     node = RosEventBridge(
@@ -215,6 +240,7 @@ def run_ros_bridge(
         pca_builder=pca_builder,
         on_pca_payload=on_pca_payload,
         on_tracking_debug=on_tracking_debug,
+        on_score=on_score,
     )
     try:
         while rclpy.ok() and not stop_event.is_set():

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -22,6 +22,7 @@ from shigure_api.config import (
     FACE_RECOGNITION_TOPIC,
     FEATURE_INFO_TOPIC,
     PCA_REBUILD_ON_NEW_USER,
+    PRESENCE_TICK_SEC,
     RECOGNITION_DEBOUNCE_SEC,
     RECOGNITION_HISTORY_TOPIC,
     RECOGNITION_SCORE_THRESHOLD,
@@ -57,6 +58,8 @@ class RosEventBridge(Node):
         self._on_score = on_score
         self._recognition_last_sent: Dict[str, float] = {}
         self._recognition_frame_count: Dict[str, int] = {}
+        # PCAプロットに反映済みの在室ユーザー集合（変化検知用）。
+        self._pca_present_published: frozenset = frozenset()
         self._lock = threading.Lock()
 
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
@@ -88,6 +91,8 @@ class RosEventBridge(Node):
             self.get_logger().info(
                 f'PCA plot listening on {FEATURE_INFO_TOPIC} and {RECOGNITION_HISTORY_TOPIC}'
             )
+            # 在室ユーザーの変化（登場/退室）を定期的に検知し、PCAプロットを再配信する。
+            self.create_timer(PRESENCE_TICK_SEC, self._on_pca_presence_tick)
             self._publish_pca_state()
 
         if self._on_tracking_debug is not None:
@@ -150,7 +155,15 @@ class RosEventBridge(Node):
     def _publish_pca_state(self) -> None:
         if self._pca_builder is None:
             return
+        self._pca_present_published = self._pca_builder.presence_signature()
         self._emit_pca(state_to_dict(self._pca_builder.build_state()))
+
+    def _on_pca_presence_tick(self) -> None:
+        """在室（確定ユーザー＋未確定people）が変化していたら、退室者を除いた最新のPCAプロットを再配信する。"""
+        if self._pca_builder is None:
+            return
+        if self._pca_builder.presence_signature() != self._pca_present_published:
+            self._publish_pca_state()
 
     def _publish_unlabeled_update(self) -> None:
         if self._pca_builder is None:
@@ -194,6 +207,9 @@ class RosEventBridge(Node):
             key = event.user_id
             # 累積スコアはデバウンスと独立に、5フレームごとに加算する。
             self.maybe_accumulate_score(key, float(face.score))
+            # PCAプロットの在室判定用に、認識フレームごとに在室をマークする。
+            if self._pca_builder is not None:
+                self._pca_builder.mark_present(key)
             # フロントへの認識通知は従来どおり30秒デバウンスで間引く。
             with self._lock:
                 last = self._recognition_last_sent.get(key, 0.0)


### PR DESCRIPTION
・FastAPIに累積スコアを送るエンドポイントを追加
・ユーザーが消えたらそのユーザーの累積スコア情報、PCAプロット情報を削除するように実装