### PR TITLE
顔が検出されなくても確定済みのユーザーのプロットを表示するように修正

### DIFF
--- a/shigure_api/shigure_api/config.py
+++ b/shigure_api/shigure_api/config.py
@@ -37,6 +37,10 @@ FEATURE_INFO_TOPIC = os.environ.get('SHIGURE_FEATURE_INFO_TOPIC', '/feature_info
 RECOGNITION_HISTORY_TOPIC = os.environ.get(
     'SHIGURE_RECOGNITION_HISTORY_TOPIC', '/shigure/recognition_history'
 )
+# 骨格追跡結果。顔が検出されなくても追跡中の people_id / face_name が毎フレーム届く。
+PEOPLE_DETECTION_TOPIC = os.environ.get(
+    'SHIGURE_PEOPLE_DETECTION_TOPIC', '/shigure/people_detection'
+)
 TRACKING_DEBUG_IMAGE_TOPIC = os.environ.get(
     'SHIGURE_TRACKING_DEBUG_IMAGE_TOPIC', '/shigure/tracking_debug_image'
 )

--- a/shigure_api/shigure_api/pca_plot.py
+++ b/shigure_api/shigure_api/pca_plot.py
@@ -309,6 +309,30 @@ class PcaPlotStateBuilder:
             people = self.present_people_ids_locked()
             return frozenset(users) | frozenset(f'people:{p}' for p in people)
 
+    def on_people_tracking(self, msg) -> None:
+        """骨格追跡(/shigure/people_detection)から在室を更新する。
+
+        顔が検出されなくても、確定済みユーザーは同じ骨格(people_id)が
+        追跡されている限りプロットを維持する。
+        """
+        now = time.monotonic()
+        with self._lock:
+            for pose in msg.pose_key_points_list:
+                people_id = pose.people_id
+                # 辞書確定済み: 骨格が残っている限り在室（顔認識不要）。
+                if people_id in self._confirmed_people:
+                    self._present_last_seen[self._confirmed_people[people_id]] = now
+                    continue
+                # pose 側の確定名（末尾?なし）も在室扱い。
+                face_name = (pose.face_name or '').strip()
+                if (
+                    face_name
+                    and not face_name.endswith('?')
+                    and face_name.startswith('user')
+                    and face_name not in ('none', 'unknown')
+                ):
+                    self._present_last_seen[face_name] = now
+
     def on_recognition_history(self, msg) -> None:
         now = time.monotonic()
         with self._lock:
@@ -316,6 +340,9 @@ class PcaPlotStateBuilder:
             for user in msg.users:
                 people_id = user.people_id
                 if people_id in self._confirmed_people:
+                    # 確定済み: 骨格が認識履歴に残っている間も在室を更新（people_detection の補助）。
+                    user_id = self._confirmed_people[people_id]
+                    self._present_last_seen[user_id] = now
                     continue
                 fns: Set[int] = set()
                 for face in user.face_info:
@@ -334,6 +361,8 @@ class PcaPlotStateBuilder:
         promoted: List[int] = []
         with self._lock:
             self._confirmed_people[people_id] = name
+            # 確定直後から在室扱い（骨格追跡が来るまでの空白を埋める）。
+            self._present_last_seen[name] = time.monotonic()
             # 確定した people は未確定の在室追跡から外す（未確定プロットとしては消す）。
             self._present_people_last_seen.pop(people_id, None)
             self._people_feature_nums.pop(people_id, None)

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -14,6 +14,7 @@ from shigure_core_msgs.msg import (
     DictionaryUpdate,
     FaceRecognitionResult,
     FeatureInfo,
+    PoseKeyPointsList,
     RecognitionHistory,
 )
 
@@ -22,6 +23,7 @@ from shigure_api.config import (
     FACE_RECOGNITION_TOPIC,
     FEATURE_INFO_TOPIC,
     PCA_REBUILD_ON_NEW_USER,
+    PEOPLE_DETECTION_TOPIC,
     PRESENCE_TICK_SEC,
     RECOGNITION_DEBOUNCE_SEC,
     RECOGNITION_HISTORY_TOPIC,
@@ -80,8 +82,15 @@ class RosEventBridge(Node):
                 self._on_feature_info,
                 shigure_qos,
             )
+            # 骨格追跡: 顔が検出されなくても、確定ユーザーの在室を people_id で維持する。
+            self.create_subscription(
+                PoseKeyPointsList,
+                PEOPLE_DETECTION_TOPIC,
+                self._on_people_detection,
+                shigure_qos,
+            )
             self.get_logger().info(
-                f'PCA plot listening on {FEATURE_INFO_TOPIC}'
+                f'PCA plot listening on {FEATURE_INFO_TOPIC} and {PEOPLE_DETECTION_TOPIC}'
             )
             # 在室ユーザーの変化（登場/退室）を定期的に検知し、PCAプロットを再配信する。
             self.create_timer(PRESENCE_TICK_SEC, self._on_pca_presence_tick)
@@ -226,6 +235,12 @@ class RosEventBridge(Node):
         self.emit_recognition_scores(recognition_scores_to_dict(msg))
         if self._pca_builder is not None:
             self._pca_builder.on_recognition_history(msg)
+
+    def _on_people_detection(self, msg: PoseKeyPointsList) -> None:
+        """骨格追跡フレームごとに確定ユーザーの在室を更新する（顔検出不要）。"""
+        if self._pca_builder is None:
+            return
+        self._pca_builder.on_people_tracking(msg)
 
     def clear_debounce(self, user_id: Optional[str] = None) -> None:
         with self._lock:


### PR DESCRIPTION
顔が検出されなくても確定済みのユーザーのプロットを表示するように修正