### PR TITLE
顔確定状況に合わせた人物BBOXの色変更，イベント表示のRich化，顔認識信頼度チューニング，PCAプロットバグ修正，骨格追跡条件緩和

### DIFF
--- a/shigure_api/shigure_api/app.py
+++ b/shigure_api/shigure_api/app.py
@@ -4,19 +4,38 @@ from __future__ import annotations
 
 import asyncio
 import queue
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncIterator, List, Set
+from typing import AsyncIterator, Dict, List, Set
 
 from fastapi import FastAPI, Header, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 
-from shigure_api.config import API_KEY, FACE_MODELS_DIR, PCA_REDRAW_EVERY, PCA_TRAJECTORY_MAX_POINTS, default_pca_model_path
-from shigure_api.events import UserEvent, UserSummary, user_event_to_dict
+from shigure_api.config import (
+    API_KEY,
+    FACE_MODELS_DIR,
+    PCA_REDRAW_EVERY,
+    PCA_TRAJECTORY_MAX_POINTS,
+    PRESENCE_TICK_SEC,
+    PRESENCE_TIMEOUT_SEC,
+    default_pca_model_path,
+)
+from shigure_api.events import UserEvent, UserSummary, cumulative_scores_to_dict, user_event_to_dict
 from shigure_api.feature_images import find_face_image_path, load_face_thumbnail
 from shigure_api.pca_plot import PcaPlotHub, PcaPlotStateBuilder
 from shigure_api.tracking_debug import TrackingDebugHub
+
+
+class _ScoreUpdate:
+    """累積スコア加算要求（ブロードキャストキュー内でイベントと区別するための内部型）。"""
+
+    __slots__ = ('user_id', 'score')
+
+    def __init__(self, user_id: str, score: float) -> None:
+        self.user_id = user_id
+        self.score = score
 
 
 class EventHub:
@@ -25,35 +44,86 @@ class EventHub:
     def __init__(self) -> None:
         self._clients: Set[WebSocket] = set()
         self._lock = asyncio.Lock()
-        self._thread_queue: queue.Queue[UserEvent] = queue.Queue()
+        self._thread_queue: queue.Queue[object] = queue.Queue()
         self._history: List[UserEvent] = []
         self._history_limit = 100
+        # 今映っているユーザーの累積スコアのみを保持する（退室でエントリごと削除）。
+        self._cumulative_scores: Dict[str, float] = {}
+        # ユーザーごとの最終認識時刻（time.monotonic()）。在室判定に使う。
+        self._last_seen: Dict[str, float] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
 
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
         asyncio.create_task(self._broadcast_loop())
+        asyncio.create_task(self.presence_loop())
 
     def enqueue(self, event: UserEvent) -> None:
         """Thread-safe enqueue from ROS callback thread."""
         self._thread_queue.put_nowait(event)
 
+    def enqueue_score(self, user_id: str, score: float) -> None:
+        """Thread-safe: ユーザーごとの累積スコアに加算する要求を投入する（ROSスレッドから）。"""
+        self._thread_queue.put_nowait(_ScoreUpdate(user_id, float(score)))
+
+    async def handle_score_update(self, update: '_ScoreUpdate') -> List[dict]:
+        if not update.user_id or update.user_id in ('none', 'unknown'):
+            return []
+        total = self._cumulative_scores.get(update.user_id, 0.0) + update.score
+        self._cumulative_scores[update.user_id] = total
+        self._last_seen[update.user_id] = time.monotonic()
+        return [cumulative_scores_to_dict(self._cumulative_scores)]
+
+    async def handle_event(self, event: UserEvent) -> List[dict]:
+        self._history.append(event)
+        if len(self._history) > self._history_limit:
+            self._history = self._history[-self._history_limit:]
+        # 累積スコアの加算は5フレームごとの専用経路で行うため、ここでは現在値を反映するのみ。
+        if event.user_id in self._cumulative_scores:
+            event.cumulative_score = self._cumulative_scores[event.user_id]
+        return [user_event_to_dict(event)]
+
+    def prune_absent(self) -> bool:
+        """在室タイムアウトを超えたユーザーを削除する。削除があれば True。"""
+        now = time.monotonic()
+        expired = [
+            user_id
+            for user_id, seen in self._last_seen.items()
+            if now - seen > PRESENCE_TIMEOUT_SEC
+        ]
+        for user_id in expired:
+            self._cumulative_scores.pop(user_id, None)
+            self._last_seen.pop(user_id, None)
+        return bool(expired)
+
+    async def broadcast(self, payloads: List[dict]) -> None:
+        async with self._lock:
+            dead: List[WebSocket] = []
+            for ws in self._clients:
+                try:
+                    for payload in payloads:
+                        await ws.send_json(payload)
+                except Exception:
+                    dead.append(ws)
+            for ws in dead:
+                self._clients.discard(ws)
+
     async def _broadcast_loop(self) -> None:
         while True:
-            event = await asyncio.to_thread(self._thread_queue.get)
-            self._history.append(event)
-            if len(self._history) > self._history_limit:
-                self._history = self._history[-self._history_limit:]
-            payload = user_event_to_dict(event)
-            async with self._lock:
-                dead: List[WebSocket] = []
-                for ws in self._clients:
-                    try:
-                        await ws.send_json(payload)
-                    except Exception:
-                        dead.append(ws)
-                for ws in dead:
-                    self._clients.discard(ws)
+            item = await asyncio.to_thread(self._thread_queue.get)
+            if isinstance(item, _ScoreUpdate):
+                payloads = await self.handle_score_update(item)
+            else:
+                payloads = await self.handle_event(item)
+            if payloads:
+                await self.broadcast(payloads)
+
+    async def presence_loop(self) -> None:
+        """定期的に退室ユーザーを除去し、変化があれば最新の在室スコアを配信する。"""
+        while True:
+            await asyncio.sleep(PRESENCE_TICK_SEC)
+            if self.prune_absent():
+                await self.broadcast([cumulative_scores_to_dict(self._cumulative_scores)])
 
     async def connect(self, websocket: WebSocket) -> None:
         await websocket.accept()
@@ -61,6 +131,9 @@ class EventHub:
             self._clients.add(websocket)
         for item in self.recent_events(limit=20):
             await websocket.send_json(item)
+        self.prune_absent()
+        if self._cumulative_scores:
+            await websocket.send_json(cumulative_scores_to_dict(self._cumulative_scores))
 
     async def disconnect(self, websocket: WebSocket) -> None:
         async with self._lock:

--- a/shigure_api/shigure_api/app.py
+++ b/shigure_api/shigure_api/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import queue
 from contextlib import asynccontextmanager
+from datetime import datetime
 from pathlib import Path
 from typing import AsyncIterator, List, Set
 
@@ -13,7 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 
 from shigure_api.config import API_KEY, FACE_MODELS_DIR, PCA_REDRAW_EVERY, PCA_TRAJECTORY_MAX_POINTS, default_pca_model_path
-from shigure_api.events import UserEvent, UserSummary, user_event_to_dict
+from shigure_api.events import ContactCandidate, UserEvent, UserSummary, contact_row_to_model, user_event_to_dict
 from shigure_api.feature_images import find_face_image_path, load_face_thumbnail
 from shigure_api.pca_plot import PcaPlotHub, PcaPlotStateBuilder
 from shigure_api.tracking_debug import TrackingDebugHub
@@ -169,6 +170,31 @@ def create_app() -> FastAPI:
     ) -> dict:
         _verify_api_key(x_api_key)
         return {'events': hub.recent_events(limit=limit)}
+
+    @app.get('/contacts', response_model=List[ContactCandidate])
+    def list_contacts(
+        date_from: datetime = Query(alias='from', description='時間窓の開始 (ISO8601)'),
+        date_to: datetime = Query(alias='to', description='時間窓の終了 (ISO8601)'),
+        action: str | None = Query(default=None, description='bring_in / take_out で絞り込む'),
+        x_api_key: str | None = Header(default=None, alias='X-API-Key'),
+    ) -> List[ContactCandidate]:
+        """指定時間窓の接触イベントを人物名・2D bbox付きで返す。
+
+        object_search_system が「時刻+bbox」で SAM2 物体に人物を帰属させるための照会口。
+        IoU 判定は呼び出し側の責務なので、ここでは候補を絞らず時間窓で返すだけにする。
+        """
+        _verify_api_key(x_api_key)
+        if date_from > date_to:
+            raise HTTPException(status_code=400, detail='from must be earlier than to')
+        try:
+            # shigure_core / mysql-connector を import 時点で要求しないよう遅延 import する
+            from shigure_core.db.event_repository import EventRepository
+
+            rows = EventRepository.select_contacts(date_from, date_to, action)
+        except Exception as exc:
+            # DB 断でも API 全体は落とさない（顔認識イベント配信は継続させる）
+            raise HTTPException(status_code=503, detail=f'DB query failed: {exc}') from exc
+        return [contact_row_to_model(row) for row in rows]
 
     @app.get('/api/users/{user_id}/features/{feature_num}/face')
     def get_feature_face(

--- a/shigure_api/shigure_api/app.py
+++ b/shigure_api/shigure_api/app.py
@@ -4,31 +4,20 @@ from __future__ import annotations
 
 import asyncio
 import queue
-import time
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import AsyncIterator, Dict, List, Set
+from typing import AsyncIterator, List, Optional, Set
 
 from fastapi import FastAPI, Header, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
-from shigure_api.config import API_KEY, FACE_MODELS_DIR, PCA_REDRAW_EVERY, PCA_TRAJECTORY_MAX_POINTS, default_pca_model_path, PRESENCE_TICK_SEC, PRESENCE_TIMEOUT_SEC
-from shigure_api.events import ContactCandidate, UserEvent, UserSummary, contact_row_to_model, user_event_to_dict, cumulative_scores_to_dict
+from shigure_api.config import API_KEY, FACE_MODELS_DIR, PCA_REDRAW_EVERY, PCA_TRAJECTORY_MAX_POINTS, default_pca_model_path
+from shigure_api.events import ContactCandidate, UserEvent, UserSummary, contact_row_to_model, user_event_to_dict
 
 from shigure_api.feature_images import find_face_image_path, load_face_thumbnail
 from shigure_api.pca_plot import PcaPlotHub, PcaPlotStateBuilder
 from shigure_api.tracking_debug import TrackingDebugHub
-
-
-class _ScoreUpdate:
-    """累積スコア加算要求（ブロードキャストキュー内でイベントと区別するための内部型）。"""
-
-    __slots__ = ('user_id', 'score')
-
-    def __init__(self, user_id: str, score: float) -> None:
-        self.user_id = user_id
-        self.score = score
 
 
 class EventHub:
@@ -40,54 +29,27 @@ class EventHub:
         self._thread_queue: queue.Queue[object] = queue.Queue()
         self._history: List[UserEvent] = []
         self._history_limit = 100
-        # 今映っているユーザーの累積スコアのみを保持する（退室でエントリごと削除）。
-        self._cumulative_scores: Dict[str, float] = {}
-        # ユーザーごとの最終認識時刻（time.monotonic()）。在室判定に使う。
-        self._last_seen: Dict[str, float] = {}
+        # 直近の累積スコア配信（cumulative_scores）。新規接続時のスナップショット用。
+        self._latest_recognition_scores: Optional[dict] = None
         self._loop: asyncio.AbstractEventLoop | None = None
 
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
         asyncio.create_task(self._broadcast_loop())
-        asyncio.create_task(self.presence_loop())
 
     def enqueue(self, event: UserEvent) -> None:
         """Thread-safe enqueue from ROS callback thread."""
         self._thread_queue.put_nowait(event)
 
-    def enqueue_score(self, user_id: str, score: float) -> None:
-        """Thread-safe: ユーザーごとの累積スコアに加算する要求を投入する（ROSスレッドから）。"""
-        self._thread_queue.put_nowait(_ScoreUpdate(user_id, float(score)))
-
-    async def handle_score_update(self, update: '_ScoreUpdate') -> List[dict]:
-        if not update.user_id or update.user_id in ('none', 'unknown'):
-            return []
-        total = self._cumulative_scores.get(update.user_id, 0.0) + update.score
-        self._cumulative_scores[update.user_id] = total
-        self._last_seen[update.user_id] = time.monotonic()
-        return [cumulative_scores_to_dict(self._cumulative_scores)]
+    def enqueue_recognition_scores(self, payload: dict) -> None:
+        """Thread-safe: RecognitionHistory 由来の累積スコア配信を投入する（ROSスレッドから）。"""
+        self._thread_queue.put_nowait(payload)
 
     async def handle_event(self, event: UserEvent) -> List[dict]:
         self._history.append(event)
         if len(self._history) > self._history_limit:
             self._history = self._history[-self._history_limit:]
-        # 累積スコアの加算は5フレームごとの専用経路で行うため、ここでは現在値を反映するのみ。
-        if event.user_id in self._cumulative_scores:
-            event.cumulative_score = self._cumulative_scores[event.user_id]
         return [user_event_to_dict(event)]
-
-    def prune_absent(self) -> bool:
-        """在室タイムアウトを超えたユーザーを削除する。削除があれば True。"""
-        now = time.monotonic()
-        expired = [
-            user_id
-            for user_id, seen in self._last_seen.items()
-            if now - seen > PRESENCE_TIMEOUT_SEC
-        ]
-        for user_id in expired:
-            self._cumulative_scores.pop(user_id, None)
-            self._last_seen.pop(user_id, None)
-        return bool(expired)
 
     async def broadcast(self, payloads: List[dict]) -> None:
         async with self._lock:
@@ -104,19 +66,15 @@ class EventHub:
     async def _broadcast_loop(self) -> None:
         while True:
             item = await asyncio.to_thread(self._thread_queue.get)
-            if isinstance(item, _ScoreUpdate):
-                payloads = await self.handle_score_update(item)
+            if isinstance(item, dict):
+                # ROS由来の完成済みペイロード（cumulative_scores 等）はそのまま配信する。
+                if item.get('type') == 'cumulative_scores':
+                    self._latest_recognition_scores = item
+                payloads = [item]
             else:
                 payloads = await self.handle_event(item)
             if payloads:
                 await self.broadcast(payloads)
-
-    async def presence_loop(self) -> None:
-        """定期的に退室ユーザーを除去し、変化があれば最新の在室スコアを配信する。"""
-        while True:
-            await asyncio.sleep(PRESENCE_TICK_SEC)
-            if self.prune_absent():
-                await self.broadcast([cumulative_scores_to_dict(self._cumulative_scores)])
 
     async def connect(self, websocket: WebSocket) -> None:
         await websocket.accept()
@@ -124,9 +82,8 @@ class EventHub:
             self._clients.add(websocket)
         for item in self.recent_events(limit=20):
             await websocket.send_json(item)
-        self.prune_absent()
-        if self._cumulative_scores:
-            await websocket.send_json(cumulative_scores_to_dict(self._cumulative_scores))
+        if self._latest_recognition_scores is not None:
+            await websocket.send_json(self._latest_recognition_scores)
 
     async def disconnect(self, websocket: WebSocket) -> None:
         async with self._lock:

--- a/shigure_api/shigure_api/config.py
+++ b/shigure_api/shigure_api/config.py
@@ -37,6 +37,10 @@ FEATURE_INFO_TOPIC = os.environ.get('SHIGURE_FEATURE_INFO_TOPIC', '/feature_info
 RECOGNITION_HISTORY_TOPIC = os.environ.get(
     'SHIGURE_RECOGNITION_HISTORY_TOPIC', '/shigure/recognition_history'
 )
+# 骨格追跡結果。顔が検出されなくても追跡中の people_id / face_name が毎フレーム届く。
+PEOPLE_DETECTION_TOPIC = os.environ.get(
+    'SHIGURE_PEOPLE_DETECTION_TOPIC', '/shigure/people_detection'
+)
 TRACKING_DEBUG_IMAGE_TOPIC = os.environ.get(
     'SHIGURE_TRACKING_DEBUG_IMAGE_TOPIC', '/shigure/tracking_debug_image'
 )

--- a/shigure_api/shigure_api/config.py
+++ b/shigure_api/shigure_api/config.py
@@ -19,6 +19,13 @@ FACE_MODELS_DIR = _default_face_models_dir()
 
 RECOGNITION_SCORE_THRESHOLD = float(os.environ.get('SHIGURE_RECOGNITION_SCORE_THRESHOLD', '0.4'))
 RECOGNITION_DEBOUNCE_SEC = float(os.environ.get('SHIGURE_RECOGNITION_DEBOUNCE_SEC', '30'))
+# 累積スコアは、閾値以上で認識されたフレームをこの回数数えるごとに1回だけ加算する。
+SCORE_ACCUMULATE_EVERY = int(os.environ.get('SHIGURE_SCORE_ACCUMULATE_EVERY', '5'))
+# 累積スコアは「今映っているユーザー」のみを配信する。最後に認識されてから
+# この秒数を超えたユーザーは退室とみなし、スコアをリセットして配信対象から外す。
+PRESENCE_TIMEOUT_SEC = float(os.environ.get('SHIGURE_PRESENCE_TIMEOUT_SEC', '1'))
+# 退室判定を行う定期チェックの間隔（秒）。
+PRESENCE_TICK_SEC = float(os.environ.get('SHIGURE_PRESENCE_TICK_SEC', '1'))
 
 API_HOST = os.environ.get('SHIGURE_API_HOST', '0.0.0.0')
 API_PORT = int(os.environ.get('SHIGURE_API_PORT', '8765'))

--- a/shigure_api/shigure_api/events.py
+++ b/shigure_api/shigure_api/events.py
@@ -30,6 +30,51 @@ class UserSummary(BaseModel):
     profile_feature_count: int = 0
 
 
+class ContactCandidate(BaseModel):
+    """接触イベント1件。object_search_system が時刻+bboxで突き合わせる候補。
+
+    bbox は [x, y, width, height]（左上原点、shigure のカメラ解像度基準）。
+    bbox 列は migration 9/10 以降にのみ入るため、それ以前の行では None になる。
+    """
+
+    shigure_event_id: str
+    action: str
+    created_at: str
+    person_id: Optional[str] = None
+    face_name: Optional[str] = None
+    object_id: Optional[str] = None
+    people_bbox: Optional[list[float]] = None
+    object_bbox: Optional[list[float]] = None
+
+
+def _bbox_or_none(x, y, w, h) -> Optional[list[float]]:
+    """4値が揃っている場合のみ [x, y, w, h] を返す。1つでも NULL なら None。"""
+    if x is None or y is None or w is None or h is None:
+        return None
+    return [float(x), float(y), float(w), float(h)]
+
+
+def contact_row_to_model(row: Dict[str, Any]) -> ContactCandidate:
+    """EventRepository.select_contacts の1行を API レスポンスに変換する。"""
+    created_at = row.get('created_at')
+    return ContactCandidate(
+        shigure_event_id=str(row.get('shigure_event_id')),
+        action=str(row.get('action')),
+        created_at=created_at.isoformat() if created_at is not None else '',
+        person_id=row.get('person_id'),
+        face_name=row.get('face_name'),
+        object_id=row.get('object_id'),
+        people_bbox=_bbox_or_none(
+            row.get('people_bbox_x'), row.get('people_bbox_y'),
+            row.get('people_bbox_width'), row.get('people_bbox_height'),
+        ),
+        object_bbox=_bbox_or_none(
+            row.get('object_bbox_x'), row.get('object_bbox_y'),
+            row.get('object_bbox_width'), row.get('object_bbox_height'),
+        ),
+    )
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 

--- a/shigure_api/shigure_api/events.py
+++ b/shigure_api/shigure_api/events.py
@@ -20,7 +20,6 @@ class UserEvent(BaseModel):
     user_id: str
     people_id: Optional[str] = None
     score: Optional[float] = None
-    cumulative_score: Optional[float] = None
     message: str
     timestamp: str = Field(default_factory=lambda: _now_iso())
 
@@ -135,10 +134,23 @@ def user_event_to_dict(event: UserEvent) -> Dict[str, Any]:
     return event.model_dump()
 
 
-def cumulative_scores_to_dict(scores: Dict[str, float]) -> Dict[str, Any]:
-    """全ユーザーの累積スコアマップを配信用の辞書に変換する。"""
+def recognition_scores_to_dict(msg) -> Dict[str, Any]:
+    """RecognitionHistory を people_id ごとの候補累積スコアへ変換する。
+
+    出力の scores は「今映っている各 people_id → 候補face_id → その累積スコア」の
+    入れ子マップになる（例: {"1": {"user_new1": 10.0, "user_new2": 1.0}}）。
+    accumulate_score は people_tracking 側で認識のたびに加算された累積値。
+    """
+    scores: Dict[str, Dict[str, float]] = {}
+    for user in msg.users:
+        candidates: Dict[str, float] = {}
+        for rec in user.face_info:
+            if not rec.id or rec.id == 'none':
+                continue
+            candidates[rec.id] = round(float(rec.accumulate_score), 4)
+        scores[user.people_id] = candidates
     return {
         'type': 'cumulative_scores',
-        'scores': {user_id: round(value, 4) for user_id, value in scores.items()},
+        'scores': scores,
         'timestamp': _now_iso(),
     }

--- a/shigure_api/shigure_api/events.py
+++ b/shigure_api/shigure_api/events.py
@@ -20,6 +20,7 @@ class UserEvent(BaseModel):
     user_id: str
     people_id: Optional[str] = None
     score: Optional[float] = None
+    cumulative_score: Optional[float] = None
     message: str
     timestamp: str = Field(default_factory=lambda: _now_iso())
 
@@ -87,3 +88,12 @@ def event_from_face_recognition(face_id: str, score: float) -> Optional[UserEven
 
 def user_event_to_dict(event: UserEvent) -> Dict[str, Any]:
     return event.model_dump()
+
+
+def cumulative_scores_to_dict(scores: Dict[str, float]) -> Dict[str, Any]:
+    """全ユーザーの累積スコアマップを配信用の辞書に変換する。"""
+    return {
+        'type': 'cumulative_scores',
+        'scores': {user_id: round(value, 4) for user_id, value in scores.items()},
+        'timestamp': _now_iso(),
+    }

--- a/shigure_api/shigure_api/feature_images.py
+++ b/shigure_api/shigure_api/feature_images.py
@@ -10,28 +10,49 @@ FACE_THUMBNAIL_SIZE = 128
 
 
 def feature_num_from_stem(user_id: str, file_stem: str) -> Optional[int]:
-    """Parse feature_num from e.g. user_new5_12628 (user_id + feature_num)."""
+    """
+    ファイル名(stem)から feature_num を取り出す.
+
+    2種類の命名に対応する:
+      - 自動登録(people_recognition): '{user_id}_{num}'  例 'user_new5_12628'
+      - 手動登録(node_face_models):   '{name}{num}'       例 'nakamura12'
+        （user_id='user_nakamura' に対し 'user_' を除いた 'nakamura' + 数字）
+    どちらにも合わなければ None。
+    """
+    # 1) 自動登録形式 '{user_id}_{num}'
     prefix = f'{user_id}_'
-    if not file_stem.startswith(prefix):
-        return None
-    suffix = file_stem[len(prefix) :]
-    if suffix.isdigit():
-        return int(suffix)
+    if file_stem.startswith(prefix):
+        suffix = file_stem[len(prefix):]
+        if suffix.isdigit():
+            return int(suffix)
+    # 2) 手動登録形式 '{name}{num}'（user_id から 'user_' を外した name + 末尾数字）
+    name = user_id[len('user_'):] if user_id.startswith('user_') else user_id
+    if name and file_stem.startswith(name):
+        suffix = file_stem[len(name):]
+        if suffix.isdigit():
+            return int(suffix)
     return None
 
 
 def find_face_image_path(
     face_models_dir: Path, user_id: str, feature_num: int
 ) -> Optional[Path]:
-    """Return user_*_{feature_num}.jpg under face_models/{user_id}/."""
+    """
+    face_models/{user_id}/ から feature_num に対応する顔画像(.jpg)を返す.
+
+    2種類の命名に対応: '{user_id}_{num}.jpg'（自動登録）/ '{name}{num}.jpg'（手動登録）。
+    """
     if not face_models_dir.is_dir() or not user_id.startswith('user_'):
         return None
-    path = face_models_dir / user_id / f'{user_id}_{feature_num}.jpg'
-    if not path.is_file():
-        return None
-    if feature_num_from_stem(user_id, path.stem) != feature_num:
-        return None
-    return path
+    name = user_id[len('user_'):]
+    candidates = [
+        face_models_dir / user_id / f'{user_id}_{feature_num}.jpg',  # 自動登録形式
+        face_models_dir / user_id / f'{name}{feature_num}.jpg',      # 手動登録形式
+    ]
+    for path in candidates:
+        if path.is_file() and feature_num_from_stem(user_id, path.stem) == feature_num:
+            return path
+    return None
 
 
 def load_face_thumbnail(path: Path, size: int = FACE_THUMBNAIL_SIZE) -> bytes:

--- a/shigure_api/shigure_api/main.py
+++ b/shigure_api/shigure_api/main.py
@@ -44,6 +44,9 @@ def main() -> None:
     def on_tracking_debug(payload: dict) -> None:
         tracking_debug_hub.enqueue(payload)
 
+    def on_score(user_id: str, score: float) -> None:
+        hub.enqueue_score(user_id, score)
+
     ros_thread = threading.Thread(
         target=run_ros_bridge,
         args=(on_event, stop_event),
@@ -51,6 +54,7 @@ def main() -> None:
             'pca_builder': pca_builder,
             'on_pca_payload': on_pca_payload,
             'on_tracking_debug': on_tracking_debug,
+            'on_score': on_score,
         },
         name='shigure_ros_bridge',
         daemon=True,

--- a/shigure_api/shigure_api/main.py
+++ b/shigure_api/shigure_api/main.py
@@ -44,8 +44,8 @@ def main() -> None:
     def on_tracking_debug(payload: dict) -> None:
         tracking_debug_hub.enqueue(payload)
 
-    def on_score(user_id: str, score: float) -> None:
-        hub.enqueue_score(user_id, score)
+    def on_recognition_scores(payload: dict) -> None:
+        hub.enqueue_recognition_scores(payload)
 
     ros_thread = threading.Thread(
         target=run_ros_bridge,
@@ -54,7 +54,7 @@ def main() -> None:
             'pca_builder': pca_builder,
             'on_pca_payload': on_pca_payload,
             'on_tracking_debug': on_tracking_debug,
-            'on_score': on_score,
+            'on_recognition_scores': on_recognition_scores,
         },
         name='shigure_ros_bridge',
         daemon=True,

--- a/shigure_api/shigure_api/pca_plot.py
+++ b/shigure_api/shigure_api/pca_plot.py
@@ -319,9 +319,14 @@ class PcaPlotStateBuilder:
                     continue
                 fns: Set[int] = set()
                 for face in user.face_info:
-                    if face.id.endswith('@profile'):
-                        continue
-                    if face.id != 'unknown':
+                    # 非正面(@profile)も含め、未認識(unknown)の顔だけを unlabeled 対象にする。
+                    # 登録ユーザーに一致した顔（'user_x' / 'user_x@profile'）は除外する。
+                    base_id = (
+                        face.id[: -len('@profile')]
+                        if face.id.endswith('@profile')
+                        else face.id
+                    )
+                    if base_id != 'unknown':
                         continue
                     fns.update(int(fn) for fn in face.features_num)
                 # 未確定 people を在室として記録し、その unlabeled 特徴番号を更新する。

--- a/shigure_api/shigure_api/pca_plot.py
+++ b/shigure_api/shigure_api/pca_plot.py
@@ -309,6 +309,30 @@ class PcaPlotStateBuilder:
             people = self.present_people_ids_locked()
             return frozenset(users) | frozenset(f'people:{p}' for p in people)
 
+    def on_people_tracking(self, msg) -> None:
+        """骨格追跡(/shigure/people_detection)から在室を更新する。
+
+        顔が検出されなくても、確定済みユーザーは同じ骨格(people_id)が
+        追跡されている限りプロットを維持する。
+        """
+        now = time.monotonic()
+        with self._lock:
+            for pose in msg.pose_key_points_list:
+                people_id = pose.people_id
+                # 辞書確定済み: 骨格が残っている限り在室（顔認識不要）。
+                if people_id in self._confirmed_people:
+                    self._present_last_seen[self._confirmed_people[people_id]] = now
+                    continue
+                # pose 側の確定名（末尾?なし）も在室扱い。
+                face_name = (pose.face_name or '').strip()
+                if (
+                    face_name
+                    and not face_name.endswith('?')
+                    and face_name.startswith('user')
+                    and face_name not in ('none', 'unknown')
+                ):
+                    self._present_last_seen[face_name] = now
+
     def on_recognition_history(self, msg) -> None:
         now = time.monotonic()
         with self._lock:
@@ -316,6 +340,9 @@ class PcaPlotStateBuilder:
             for user in msg.users:
                 people_id = user.people_id
                 if people_id in self._confirmed_people:
+                    # 確定済み: 骨格が認識履歴に残っている間も在室を更新（people_detection の補助）。
+                    user_id = self._confirmed_people[people_id]
+                    self._present_last_seen[user_id] = now
                     continue
                 fns: Set[int] = set()
                 for face in user.face_info:
@@ -334,6 +361,8 @@ class PcaPlotStateBuilder:
         promoted: List[int] = []
         with self._lock:
             self._confirmed_people[people_id] = name
+            # 確定直後から在室扱い（骨格追跡が来るまでの空白を埋める）。
+            self._present_last_seen[name] = time.monotonic()
             # 確定した people は未確定の在室追跡から外す（未確定プロットとしては消す）。
             self._present_people_last_seen.pop(people_id, None)
             self._people_feature_nums.pop(people_id, None)

--- a/shigure_api/shigure_api/pca_plot.py
+++ b/shigure_api/shigure_api/pca_plot.py
@@ -371,6 +371,14 @@ class PcaPlotStateBuilder:
                 for fn, pt in sorted(self._unlabeled.items())
                 if fn in present_fns
             ]
+            # デバッグ: FeatureInfo 到着ごと（5フレーム毎）の点数。顔が映っている間に出る。
+            print(
+                f'[pca][B:unlabeled_update] seq={self._sequence} '
+                f'unlabeled_total={len(self._unlabeled)} present_fns={len(present_fns)} '
+                f'unlabeled_shown={len(unlabeled)} '
+                f'present_people={sorted(self._present_people_last_seen.keys())}',
+                flush=True,
+            )
             return PcaUnlabeledUpdate(
                 timestamp=_now_iso(),
                 sequence=self._sequence,
@@ -397,6 +405,20 @@ class PcaPlotStateBuilder:
             ]
             # 今映っているユーザーのプロット（dictionary / labeled_new）だけを含める。
             present = self.present_user_ids_locked()
+            dict_shown = sum(1 for k in self._dictionary if k in present)
+            labeled_shown = sum(1 for k in self._labeled_new if k in present)
+            # デバッグ: 点の生成有無と在室フィルタ通過後の件数を並べて出す。
+            # unlabeled_total>0 かつ unlabeled_shown==0 なら「点はあるがフィルタで全除外」。
+            print(
+                f'[pca][A:build_state] seq={self._sequence} '
+                f'unlabeled_total={len(self._unlabeled)} present_fns={len(present_fns)} '
+                f'unlabeled_shown={len(unlabeled)} '
+                f'dict_total={len(self._dictionary)} dict_shown={dict_shown} '
+                f'labeled_total={len(self._labeled_new)} labeled_shown={labeled_shown} '
+                f'present_users={sorted(present)} '
+                f'present_people={sorted(self._present_people_last_seen.keys())}',
+                flush=True,
+            )
             return PcaPlotState(
                 timestamp=_now_iso(),
                 sequence=self._sequence,

--- a/shigure_api/shigure_api/pca_plot.py
+++ b/shigure_api/shigure_api/pca_plot.py
@@ -6,6 +6,7 @@ import asyncio
 import pickle
 import queue
 import threading
+import time
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,7 @@ from typing import Any, Dict, List, Literal, Optional, Set, Tuple
 
 from pydantic import BaseModel
 
+from shigure_api.config import PRESENCE_TIMEOUT_SEC
 from shigure_api.feature_images import feature_num_from_stem
 
 Point2D = Tuple[float, float]
@@ -151,10 +153,17 @@ class PcaPlotStateBuilder:
         *,
         redraw_every: int = 5,
         trajectory_max_points: int = 50,
+        presence_timeout: float = PRESENCE_TIMEOUT_SEC,
     ) -> None:
         self._lock = threading.Lock()
         self._redraw_every = max(1, redraw_every)
         self._trajectory_max_points = max(2, trajectory_max_points)
+        # 今映っているユーザーのみプロットするための在室追跡（user_id -> 最終認識時刻）。
+        self._presence_timeout = max(0.0, presence_timeout)
+        self._present_last_seen: Dict[str, float] = {}
+        # 未確定ユーザー（people_id 単位）の在室追跡と、その people が持つ unlabeled 特徴番号。
+        self._present_people_last_seen: Dict[str, float] = {}
+        self._people_feature_nums: Dict[str, Set[int]] = {}
         self._sequence = 0
         self._feature_counter = 0
         self._face_models_dir = face_models_dir
@@ -248,9 +257,76 @@ class PcaPlotStateBuilder:
         with self._lock:
             self._labeled_new.pop(user_id, None)
 
+    def mark_present(self, user_id: str) -> None:
+        """ユーザーが認識されたことを記録する（在室扱いにする）。認識フレームごとに呼ぶ。"""
+        if not user_id or user_id in ('none', 'unknown'):
+            return
+        with self._lock:
+            self._present_last_seen[user_id] = time.monotonic()
+
+    def present_user_ids_locked(self) -> Set[str]:
+        """在室タイムアウトを超えたユーザーを除去し、今映っている user_id 集合を返す（要ロック済み）。"""
+        now = time.monotonic()
+        expired = [
+            user_id
+            for user_id, seen in self._present_last_seen.items()
+            if now - seen > self._presence_timeout
+        ]
+        for user_id in expired:
+            self._present_last_seen.pop(user_id, None)
+        return set(self._present_last_seen.keys())
+
+    def present_user_ids(self) -> Set[str]:
+        """今映っている user_id 集合を返す（退室分は除去済み）。"""
+        with self._lock:
+            return self.present_user_ids_locked()
+
+    def present_people_ids_locked(self) -> Set[str]:
+        """在室タイムアウトを超えた未確定 people を除去し、今映っている people_id 集合を返す（要ロック済み）。"""
+        now = time.monotonic()
+        expired = [
+            people_id
+            for people_id, seen in self._present_people_last_seen.items()
+            if now - seen > self._presence_timeout
+        ]
+        for people_id in expired:
+            self._present_people_last_seen.pop(people_id, None)
+            self._people_feature_nums.pop(people_id, None)
+        return set(self._present_people_last_seen.keys())
+
+    def present_unlabeled_fns_locked(self) -> Set[int]:
+        """今映っている未確定 people が持つ unlabeled 特徴番号の集合を返す（要ロック済み）。"""
+        present_people = self.present_people_ids_locked()
+        fns: Set[int] = set()
+        for people_id in present_people:
+            fns |= self._people_feature_nums.get(people_id, set())
+        return fns
+
+    def presence_signature(self) -> frozenset:
+        """確定ユーザーと未確定 people を合わせた在室シグネチャ（変化検知用）。"""
+        with self._lock:
+            users = self.present_user_ids_locked()
+            people = self.present_people_ids_locked()
+            return frozenset(users) | frozenset(f'people:{p}' for p in people)
+
     def on_recognition_history(self, msg) -> None:
+        now = time.monotonic()
         with self._lock:
             self._latest_history = msg
+            for user in msg.users:
+                people_id = user.people_id
+                if people_id in self._confirmed_people:
+                    continue
+                fns: Set[int] = set()
+                for face in user.face_info:
+                    if face.id.endswith('@profile'):
+                        continue
+                    if face.id != 'unknown':
+                        continue
+                    fns.update(int(fn) for fn in face.features_num)
+                # 未確定 people を在室として記録し、その unlabeled 特徴番号を更新する。
+                self._present_people_last_seen[people_id] = now
+                self._people_feature_nums[people_id] = fns
 
     def on_dictionary_update(self, people_id: str, name: str) -> Optional[PcaSegmentClosed]:
         if not name or name == 'none':
@@ -258,6 +334,9 @@ class PcaPlotStateBuilder:
         promoted: List[int] = []
         with self._lock:
             self._confirmed_people[people_id] = name
+            # 確定した people は未確定の在室追跡から外す（未確定プロットとしては消す）。
+            self._present_people_last_seen.pop(people_id, None)
+            self._people_feature_nums.pop(people_id, None)
             if self._latest_history is not None:
                 for user in self._latest_history.users:
                     if user.people_id != people_id:
@@ -286,9 +365,11 @@ class PcaPlotStateBuilder:
     def build_unlabeled_update(self) -> PcaUnlabeledUpdate:
         with self._lock:
             self._sequence += 1
+            present_fns = self.present_unlabeled_fns_locked()
             unlabeled = [
                 PcaPlotPoint(feature_num=fn, x=pt[0], y=pt[1])
                 for fn, pt in sorted(self._unlabeled.items())
+                if fn in present_fns
             ]
             return PcaUnlabeledUpdate(
                 timestamp=_now_iso(),
@@ -306,16 +387,25 @@ class PcaPlotStateBuilder:
     def build_state(self) -> PcaPlotState:
         with self._lock:
             self._sequence += 1
+            # 未確定 people の在室（＋その unlabeled 特徴番号）を先に確定させる。
+            present_fns = self.present_unlabeled_fns_locked()
             trajectories = self._build_trajectories_pre_confirm()
             unlabeled = [
                 PcaPlotPoint(feature_num=fn, x=pt[0], y=pt[1])
                 for fn, pt in sorted(self._unlabeled.items())
+                if fn in present_fns
             ]
+            # 今映っているユーザーのプロット（dictionary / labeled_new）だけを含める。
+            present = self.present_user_ids_locked()
             return PcaPlotState(
                 timestamp=_now_iso(),
                 sequence=self._sequence,
-                dictionary={k: list(v) for k, v in self._dictionary.items()},
-                labeled_new={k: list(v) for k, v in self._labeled_new.items()},
+                dictionary={
+                    k: list(v) for k, v in self._dictionary.items() if k in present
+                },
+                labeled_new={
+                    k: list(v) for k, v in self._labeled_new.items() if k in present
+                },
                 unlabeled=unlabeled,
                 trajectories_pre_confirm=trajectories,
             )
@@ -327,6 +417,9 @@ class PcaPlotStateBuilder:
         for user in self._latest_history.users:
             people_id = user.people_id
             if people_id in self._confirmed_people:
+                continue
+            # 退室（在室タイムアウト超過）した未確定 people の軌跡は出さない。
+            if people_id not in self._present_people_last_seen:
                 continue
             feature_nums: List[int] = []
             for face in user.face_info:

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -25,6 +25,7 @@ from shigure_api.config import (
     RECOGNITION_DEBOUNCE_SEC,
     RECOGNITION_HISTORY_TOPIC,
     RECOGNITION_SCORE_THRESHOLD,
+    SCORE_ACCUMULATE_EVERY,
     TRACKING_DEBUG_IMAGE_TOPIC,
 )
 from shigure_api.events import event_from_dictionary_update, event_from_face_recognition
@@ -46,13 +47,16 @@ class RosEventBridge(Node):
         pca_builder: Optional[PcaPlotStateBuilder] = None,
         on_pca_payload: Optional[Callable[[dict], None]] = None,
         on_tracking_debug: Optional[Callable[[dict], None]] = None,
+        on_score: Optional[Callable[[str, float], None]] = None,
     ):
         super().__init__('shigure_api_bridge')
         self._on_event = on_event
         self._pca_builder = pca_builder
         self._on_pca_payload = on_pca_payload
         self._on_tracking_debug = on_tracking_debug
+        self._on_score = on_score
         self._recognition_last_sent: Dict[str, float] = {}
+        self._recognition_frame_count: Dict[str, int] = {}
         self._lock = threading.Lock()
 
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
@@ -123,6 +127,23 @@ class RosEventBridge(Node):
         except Exception as exc:
             self.get_logger().error(f'Failed to emit tracking debug image: {exc}')
 
+    def emit_score(self, user_id: str, score: float) -> None:
+        if self._on_score is None:
+            return
+        try:
+            self._on_score(user_id, score)
+        except Exception as exc:
+            self.get_logger().error(f'Failed to emit score: {exc}')
+
+    def maybe_accumulate_score(self, user_id: str, score: float) -> None:
+        """閾値以上で認識されたフレームを数え、SCORE_ACCUMULATE_EVERY 回ごとに1回だけ加算する。"""
+        if self._on_score is None:
+            return
+        count = self._recognition_frame_count.get(user_id, 0) + 1
+        self._recognition_frame_count[user_id] = count
+        if count % SCORE_ACCUMULATE_EVERY == 0:
+            self.emit_score(user_id, score)
+
     def _on_tracking_debug_image(self, msg: DebugImage) -> None:
         self._emit_tracking_debug(debug_image_msg_to_payload(msg))
 
@@ -171,6 +192,9 @@ class RosEventBridge(Node):
             if event is None:
                 continue
             key = event.user_id
+            # 累積スコアはデバウンスと独立に、5フレームごとに加算する。
+            self.maybe_accumulate_score(key, float(face.score))
+            # フロントへの認識通知は従来どおり30秒デバウンスで間引く。
             with self._lock:
                 last = self._recognition_last_sent.get(key, 0.0)
                 if now - last < RECOGNITION_DEBOUNCE_SEC:
@@ -208,6 +232,7 @@ def run_ros_bridge(
     pca_builder: Optional[PcaPlotStateBuilder] = None,
     on_pca_payload: Optional[Callable[[dict], None]] = None,
     on_tracking_debug: Optional[Callable[[dict], None]] = None,
+    on_score: Optional[Callable[[str, float], None]] = None,
 ) -> None:
     rclpy.init()
     node = RosEventBridge(
@@ -215,6 +240,7 @@ def run_ros_bridge(
         pca_builder=pca_builder,
         on_pca_payload=on_pca_payload,
         on_tracking_debug=on_tracking_debug,
+        on_score=on_score,
     )
     try:
         while rclpy.ok() and not stop_event.is_set():

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -22,6 +22,7 @@ from shigure_api.config import (
     FACE_RECOGNITION_TOPIC,
     FEATURE_INFO_TOPIC,
     PCA_REBUILD_ON_NEW_USER,
+    PRESENCE_TICK_SEC,
     RECOGNITION_DEBOUNCE_SEC,
     RECOGNITION_HISTORY_TOPIC,
     RECOGNITION_SCORE_THRESHOLD,
@@ -57,6 +58,8 @@ class RosEventBridge(Node):
         self._on_score = on_score
         self._recognition_last_sent: Dict[str, float] = {}
         self._recognition_frame_count: Dict[str, int] = {}
+        # PCAプロットに反映済みの在室ユーザー集合（変化検知用）。
+        self._pca_present_published: frozenset = frozenset()
         self._lock = threading.Lock()
 
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
@@ -88,6 +91,8 @@ class RosEventBridge(Node):
             self.get_logger().info(
                 f'PCA plot listening on {FEATURE_INFO_TOPIC} and {RECOGNITION_HISTORY_TOPIC}'
             )
+            # 在室ユーザーの変化（登場/退室）を定期的に検知し、PCAプロットを再配信する。
+            self.create_timer(PRESENCE_TICK_SEC, self._on_pca_presence_tick)
             self._publish_pca_state()
 
         if self._on_tracking_debug is not None:
@@ -150,7 +155,15 @@ class RosEventBridge(Node):
     def _publish_pca_state(self) -> None:
         if self._pca_builder is None:
             return
+        self._pca_present_published = self._pca_builder.presence_signature()
         self._emit_pca(state_to_dict(self._pca_builder.build_state()))
+
+    def _on_pca_presence_tick(self) -> None:
+        """在室（確定ユーザー＋未確定people）が変化していたら、退室者を除いた最新のPCAプロットを再配信する。"""
+        if self._pca_builder is None:
+            return
+        if self._pca_builder.presence_signature() != self._pca_present_published:
+            self._publish_pca_state()
 
     def _publish_unlabeled_update(self) -> None:
         if self._pca_builder is None:
@@ -194,6 +207,9 @@ class RosEventBridge(Node):
             key = event.user_id
             # 累積スコアはデバウンスと独立に、5フレームごとに加算する。
             self.maybe_accumulate_score(key, float(face.score))
+            # PCAプロットの在室判定用に、認識フレームごとに在室をマークする。
+            if self._pca_builder is not None:
+                self._pca_builder.mark_present(key)
             # フロントへの認識通知は従来どおり30秒デバウンスで間引く。
             with self._lock:
                 last = self._recognition_last_sent.get(key, 0.0)

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -26,10 +26,9 @@ from shigure_api.config import (
     RECOGNITION_DEBOUNCE_SEC,
     RECOGNITION_HISTORY_TOPIC,
     RECOGNITION_SCORE_THRESHOLD,
-    SCORE_ACCUMULATE_EVERY,
     TRACKING_DEBUG_IMAGE_TOPIC,
 )
-from shigure_api.events import event_from_dictionary_update, event_from_face_recognition
+from shigure_api.events import event_from_dictionary_update, event_from_face_recognition, recognition_scores_to_dict
 from shigure_api.pca_plot import (
     PcaPlotStateBuilder,
     segment_closed_to_dict,
@@ -48,16 +47,15 @@ class RosEventBridge(Node):
         pca_builder: Optional[PcaPlotStateBuilder] = None,
         on_pca_payload: Optional[Callable[[dict], None]] = None,
         on_tracking_debug: Optional[Callable[[dict], None]] = None,
-        on_score: Optional[Callable[[str, float], None]] = None,
+        on_recognition_scores: Optional[Callable[[dict], None]] = None,
     ):
         super().__init__('shigure_api_bridge')
         self._on_event = on_event
         self._pca_builder = pca_builder
         self._on_pca_payload = on_pca_payload
         self._on_tracking_debug = on_tracking_debug
-        self._on_score = on_score
+        self._on_recognition_scores = on_recognition_scores
         self._recognition_last_sent: Dict[str, float] = {}
-        self._recognition_frame_count: Dict[str, int] = {}
         # PCAプロットに反映済みの在室ユーザー集合（変化検知用）。
         self._pca_present_published: frozenset = frozenset()
         self._lock = threading.Lock()
@@ -82,6 +80,15 @@ class RosEventBridge(Node):
                 self._on_feature_info,
                 shigure_qos,
             )
+            self.get_logger().info(
+                f'PCA plot listening on {FEATURE_INFO_TOPIC}'
+            )
+            # 在室ユーザーの変化（登場/退室）を定期的に検知し、PCAプロットを再配信する。
+            self.create_timer(PRESENCE_TICK_SEC, self._on_pca_presence_tick)
+            self._publish_pca_state()
+
+        # RecognitionHistory は PCAプロットと累積スコア配信の両方で使う。
+        if self._pca_builder is not None or self._on_recognition_scores is not None:
             self.create_subscription(
                 RecognitionHistory,
                 RECOGNITION_HISTORY_TOPIC,
@@ -89,11 +96,8 @@ class RosEventBridge(Node):
                 10,
             )
             self.get_logger().info(
-                f'PCA plot listening on {FEATURE_INFO_TOPIC} and {RECOGNITION_HISTORY_TOPIC}'
+                f'Recognition history listening on {RECOGNITION_HISTORY_TOPIC}'
             )
-            # 在室ユーザーの変化（登場/退室）を定期的に検知し、PCAプロットを再配信する。
-            self.create_timer(PRESENCE_TICK_SEC, self._on_pca_presence_tick)
-            self._publish_pca_state()
 
         if self._on_tracking_debug is not None:
             self.create_subscription(
@@ -132,22 +136,13 @@ class RosEventBridge(Node):
         except Exception as exc:
             self.get_logger().error(f'Failed to emit tracking debug image: {exc}')
 
-    def emit_score(self, user_id: str, score: float) -> None:
-        if self._on_score is None:
+    def emit_recognition_scores(self, payload: dict) -> None:
+        if self._on_recognition_scores is None:
             return
         try:
-            self._on_score(user_id, score)
+            self._on_recognition_scores(payload)
         except Exception as exc:
-            self.get_logger().error(f'Failed to emit score: {exc}')
-
-    def maybe_accumulate_score(self, user_id: str, score: float) -> None:
-        """閾値以上で認識されたフレームを数え、SCORE_ACCUMULATE_EVERY 回ごとに1回だけ加算する。"""
-        if self._on_score is None:
-            return
-        count = self._recognition_frame_count.get(user_id, 0) + 1
-        self._recognition_frame_count[user_id] = count
-        if count % SCORE_ACCUMULATE_EVERY == 0:
-            self.emit_score(user_id, score)
+            self.get_logger().error(f'Failed to emit recognition scores: {exc}')
 
     def _on_tracking_debug_image(self, msg: DebugImage) -> None:
         self._emit_tracking_debug(debug_image_msg_to_payload(msg))
@@ -205,8 +200,6 @@ class RosEventBridge(Node):
             if event is None:
                 continue
             key = event.user_id
-            # 累積スコアはデバウンスと独立に、5フレームごとに加算する。
-            self.maybe_accumulate_score(key, float(face.score))
             # PCAプロットの在室判定用に、認識フレームごとに在室をマークする。
             if self._pca_builder is not None:
                 self._pca_builder.mark_present(key)
@@ -229,9 +222,10 @@ class RosEventBridge(Node):
             self._publish_unlabeled_update()
 
     def _on_recognition_history(self, msg: RecognitionHistory) -> None:
-        if self._pca_builder is None:
-            return
-        self._pca_builder.on_recognition_history(msg)
+        # 今映っている people_id ごとの候補累積スコアをフロントへ配信する。
+        self.emit_recognition_scores(recognition_scores_to_dict(msg))
+        if self._pca_builder is not None:
+            self._pca_builder.on_recognition_history(msg)
 
     def clear_debounce(self, user_id: Optional[str] = None) -> None:
         with self._lock:
@@ -248,7 +242,7 @@ def run_ros_bridge(
     pca_builder: Optional[PcaPlotStateBuilder] = None,
     on_pca_payload: Optional[Callable[[dict], None]] = None,
     on_tracking_debug: Optional[Callable[[dict], None]] = None,
-    on_score: Optional[Callable[[str, float], None]] = None,
+    on_recognition_scores: Optional[Callable[[dict], None]] = None,
 ) -> None:
     rclpy.init()
     node = RosEventBridge(
@@ -256,7 +250,7 @@ def run_ros_bridge(
         pca_builder=pca_builder,
         on_pca_payload=on_pca_payload,
         on_tracking_debug=on_tracking_debug,
-        on_score=on_score,
+        on_recognition_scores=on_recognition_scores,
     )
     try:
         while rclpy.ok() and not stop_event.is_set():

--- a/shigure_api/shigure_api/ros_bridge.py
+++ b/shigure_api/shigure_api/ros_bridge.py
@@ -14,6 +14,7 @@ from shigure_core_msgs.msg import (
     DictionaryUpdate,
     FaceRecognitionResult,
     FeatureInfo,
+    PoseKeyPointsList,
     RecognitionHistory,
 )
 
@@ -22,6 +23,7 @@ from shigure_api.config import (
     FACE_RECOGNITION_TOPIC,
     FEATURE_INFO_TOPIC,
     PCA_REBUILD_ON_NEW_USER,
+    PEOPLE_DETECTION_TOPIC,
     PRESENCE_TICK_SEC,
     RECOGNITION_DEBOUNCE_SEC,
     RECOGNITION_HISTORY_TOPIC,
@@ -80,8 +82,15 @@ class RosEventBridge(Node):
                 self._on_feature_info,
                 shigure_qos,
             )
+            # 骨格追跡: 顔が検出されなくても、確定ユーザーの在室を people_id で維持する。
+            self.create_subscription(
+                PoseKeyPointsList,
+                PEOPLE_DETECTION_TOPIC,
+                self._on_people_detection,
+                shigure_qos,
+            )
             self.get_logger().info(
-                f'PCA plot listening on {FEATURE_INFO_TOPIC}'
+                f'PCA plot listening on {FEATURE_INFO_TOPIC} and {PEOPLE_DETECTION_TOPIC}'
             )
             # 在室ユーザーの変化（登場/退室）を定期的に検知し、PCAプロットを再配信する。
             self.create_timer(PRESENCE_TICK_SEC, self._on_pca_presence_tick)
@@ -226,6 +235,12 @@ class RosEventBridge(Node):
         self.emit_recognition_scores(recognition_scores_to_dict(msg))
         if self._pca_builder is not None:
             self._pca_builder.on_recognition_history(msg)
+
+    def _on_people_detection(self, msg: PoseKeyPointsList) -> None:
+        """骨格追跡フレームごとに確定ユーザーの在室を更新する（顔検出不要）。"""
+        if self._pca_builder is None:
+            return
+        self._pca_builder.on_people_tracking(msg)
 
     def clear_debounce(self, user_id: Optional[str] = None) -> None:
         with self._lock:

--- a/shigure_core/resource/db/migration/10_add_bbox_to_object.down.sql
+++ b/shigure_core/resource/db/migration/10_add_bbox_to_object.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `object`
+  DROP COLUMN `bbox_height`,
+  DROP COLUMN `bbox_width`,
+  DROP COLUMN `bbox_y`,
+  DROP COLUMN `bbox_x`;

--- a/shigure_core/resource/db/migration/10_add_bbox_to_object.up.sql
+++ b/shigure_core/resource/db/migration/10_add_bbox_to_object.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `object`
+  ADD COLUMN `bbox_x` FLOAT NULL DEFAULT NULL AFTER `depth`,
+  ADD COLUMN `bbox_y` FLOAT NULL DEFAULT NULL AFTER `bbox_x`,
+  ADD COLUMN `bbox_width` FLOAT NULL DEFAULT NULL AFTER `bbox_y`,
+  ADD COLUMN `bbox_height` FLOAT NULL DEFAULT NULL AFTER `bbox_width`;

--- a/shigure_core/resource/db/migration/9_add_bbox_to_people.down.sql
+++ b/shigure_core/resource/db/migration/9_add_bbox_to_people.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `people`
+  DROP COLUMN `bbox_y`,
+  DROP COLUMN `bbox_x`;

--- a/shigure_core/resource/db/migration/9_add_bbox_to_people.up.sql
+++ b/shigure_core/resource/db/migration/9_add_bbox_to_people.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `people`
+  ADD COLUMN `bbox_x` FLOAT NULL DEFAULT NULL AFTER `icon_height`,
+  ADD COLUMN `bbox_y` FLOAT NULL DEFAULT NULL AFTER `bbox_x`;

--- a/shigure_core/shigure_core/db/event_repository.py
+++ b/shigure_core/shigure_core/db/event_repository.py
@@ -130,6 +130,44 @@ class EventRepository:
         return pose_id
 
     @staticmethod
+    def select_contacts(date_from, date_to, action: str = None):
+        """指定時間窓の接触イベントを、人物名と2D bbox付きで返す。
+
+        object_search_system が「時刻+bbox」でSAM2物体と人物を突き合わせるための照会用。
+        IoU判定は呼び出し側で行うため、ここでは候補を返すだけにする。
+        人物bboxの幅・高さは icon_width/icon_height を流用している（insert_people 参照）。
+        """
+        ctx = mysql.connector.connect(**config)
+        cur = ctx.cursor(dictionary=True)
+
+        sql = (
+            "SELECT e.id AS shigure_event_id, e.action, e.created_at, "
+            "p.person_id, p.name AS face_name, "
+            "p.bbox_x AS people_bbox_x, p.bbox_y AS people_bbox_y, "
+            "p.icon_width AS people_bbox_width, p.icon_height AS people_bbox_height, "
+            "o.object_id, "
+            "o.bbox_x AS object_bbox_x, o.bbox_y AS object_bbox_y, "
+            "o.bbox_width AS object_bbox_width, o.bbox_height AS object_bbox_height "
+            "FROM event e "
+            "JOIN people p ON e.people_id = p.id "
+            "JOIN object o ON e.object_id = o.id "
+            "WHERE e.created_at >= %s AND e.created_at <= %s"
+        )
+        params = [date_from, date_to]
+
+        if action:
+            sql += " AND e.action = %s"
+            params.append(action)
+
+        sql += " ORDER BY e.created_at ASC"
+
+        cur.execute(sql, tuple(params))
+        rows = cur.fetchall()
+        ctx.close()
+
+        return rows
+
+    @staticmethod
     def select_with_count(page: int):
         ctx = mysql.connector.connect(**config)
         cur = ctx.cursor()

--- a/shigure_core/shigure_core/db/event_repository.py
+++ b/shigure_core/shigure_core/db/event_repository.py
@@ -7,20 +7,28 @@ from shigure_core.db.convert_format import ConvertMsg
 class EventRepository:
 
     @staticmethod
-    def insert_people(person_id: str, name: str, icon_path: str, icon_width: int, icon_height: int):
+    def insert_people(person_id: str, name: str, icon_path: str, icon_width: int, icon_height: int,
+                      bbox_x: float = None, bbox_y: float = None):
+        # bbox_x/bbox_y は接触時の人物2D bboxの左上原点。幅・高さは icon_width/icon_height を流用する。
         ctx = mysql.connector.connect(**config)
         cur = ctx.cursor()
-        sql = "INSERT INTO people(person_id, name, icon_path, icon_width, icon_height) VALUES (%s, %s, %s, %s, %s)"
-        cur.execute(sql, (person_id, name, icon_path, icon_width, icon_height))
+        sql = ("INSERT INTO people(person_id, name, icon_path, icon_width, icon_height, bbox_x, bbox_y) "
+               "VALUES (%s, %s, %s, %s, %s, %s, %s)")
+        cur.execute(sql, (person_id, name, icon_path, icon_width, icon_height, bbox_x, bbox_y))
         ctx.commit()
         ctx.close()
 
     @staticmethod
-    def insert_object(object_id: str, icon_path: str, x: float, y: float, z: float, width: float, height: float, depth: float):
+    def insert_object(object_id: str, icon_path: str, x: float, y: float, z: float, width: float, height: float, depth: float,
+                      bbox_x: float = None, bbox_y: float = None, bbox_width: float = None, bbox_height: float = None):
+        # x/y/z/width/height/depth は3次元コライダー。bbox_* は接触時の物体2D bbox（別物なので別カラム）。
         ctx = mysql.connector.connect(**config)
         cur = ctx.cursor()
-        sql = f"INSERT INTO object(object_id, icon_path, x, y, z, width, height, depth) VALUES ('{object_id}', '{icon_path}', '{x}', '{y}', '{z}', '{width}', '{height}', '{depth}')"
-        cur.execute(sql)
+        sql = ("INSERT INTO object(object_id, icon_path, x, y, z, width, height, depth, "
+               "bbox_x, bbox_y, bbox_width, bbox_height) "
+               "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)")
+        cur.execute(sql, (object_id, icon_path, x, y, z, width, height, depth,
+                          bbox_x, bbox_y, bbox_width, bbox_height))
         ctx.commit()
         ctx.close()
 

--- a/shigure_core/shigure_core/nodes/node_contact_detection.py
+++ b/shigure_core/shigure_core/nodes/node_contact_detection.py
@@ -152,11 +152,14 @@ class ContactDetectionNode(ImagePreviewNode):
             
             #print(action.value)
 
+            # DB/HoloLens へ流す face_name は「確定名」のみ。暫定('?'付き)は保存・送信しない。
+            confirmed_face_name = '' if person.face_name.endswith('?') else person.face_name
+
             if action != ContactActionEnum.TOUCH:
                 contacted = Contacted()
                 contacted.event_id = self._id_manager.new_event_id()
                 contacted.people_id = person.people_id
-                contacted.face_name = person.face_name
+                contacted.face_name = confirmed_face_name
                 contacted.object_id = tracked_object.object_id
                 contacted.action = action.value
                 contacted.people_bounding_box = person.bounding_box
@@ -167,7 +170,7 @@ class ContactDetectionNode(ImagePreviewNode):
                 # TOUCHの場合はevent idを追加せずにpublish
                 contacted = Contacted()
                 contacted.people_id = person.people_id
-                contacted.face_name = person.face_name
+                contacted.face_name = confirmed_face_name
                 contacted.object_id = tracked_object.object_id
                 contacted.action = action.value
                 contacted.people_bounding_box = person.bounding_box
@@ -213,20 +216,21 @@ class ContactDetectionNode(ImagePreviewNode):
                 cv2.circle(color_img, (x, y), 5, (255, 0, 0), thickness=-1)
                 cv2.circle(event_frame, (x, y), 5, (255, 0, 0), thickness=-1)
 
-                # 顔認証で名前が確定していれば名前を併記する(未確定時はface_nameは空文字)
-                people_label = f'ID : {re.sub(".*_", "", person.people_id)}'
-                if person.face_name:
-                    people_label = f'{people_label} ({person.face_name})'
+                # 顔と骨格の結合状態で枠色とラベルを決める（people_tracking と統一）:
+                #   確定('user_xxx')  → 青 ＋ 名前
+                #   暫定('user_xxx?') → 赤 ＋ 名前?
+                #   未結合('')        → 灰 ＋ 'ID : n'
+                p_color, people_label = self.get_person_box_color_label(person)
 
-                cv2.rectangle(color_img, (left, top), (right, bottom), (255, 0, 0), thickness=3)
-                cv2.rectangle(event_frame, (left, top), (right, bottom), (255, 0, 0), thickness=3)
-                text_w, text_h = cv2.getTextSize(people_label, cv2.FONT_HERSHEY_PLAIN, 1.5, 2)[0]
-                cv2.rectangle(color_img, (left, top), (left + text_w, top - text_h), (255, 0, 0), -1)
-                cv2.rectangle(event_frame, (left, top), (left + text_w, top - text_h), (255, 0, 0), -1)
-                cv2.putText(color_img, people_label, (left, top),
-                            cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
-                cv2.putText(event_frame, people_label, (left, top),
-                            cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
+                cv2.rectangle(color_img, (left, top), (right, bottom), p_color, thickness=3)
+                cv2.rectangle(event_frame, (left, top), (right, bottom), p_color, thickness=3)
+                text_w, text_h = cv2.getTextSize(people_label, cv2.FONT_HERSHEY_PLAIN, 2.5, 3)[0]
+                cv2.rectangle(color_img, (left, top - text_h - 6), (left + text_w, top), p_color, -1)
+                cv2.rectangle(event_frame, (left, top - text_h - 6), (left + text_w, top), p_color, -1)
+                cv2.putText(color_img, people_label, (left, top - 4),
+                            cv2.FONT_HERSHEY_PLAIN, 2.5, (255, 255, 255), thickness=3)
+                cv2.putText(event_frame, people_label, (left, top - 4),
+                            cv2.FONT_HERSHEY_PLAIN, 2.5, (255, 255, 255), thickness=3)
                 
 
             # すべての物体領域を書く
@@ -258,7 +262,19 @@ class ContactDetectionNode(ImagePreviewNode):
                         object_image = event_frame[top_expansion : bottom_expansion, left_expansion : right_expansion]
                     else:
                         object_image = event_frame[top : bottom, left : right]
+                    # 拡大表示のサイズ(左上に3倍で貼られる)を控えておく
+                    thumb_h = min(object_image.shape[0] * 3, height)
+                    thumb_w = min(object_image.shape[1] * 3, width)
                     event_frame = self.overlay_image(overlapping_img=object_image, underlying_img=event_frame, shift=(0, 0), resize_scale=(3, 3), is_frame_line=True)
+
+                    # ③ 物体拡大画像の右側に大きな矢印を描画する。
+                    # 右上は時系列キャプション(latest等)を置くので、矢印は少し下げて被りを避ける。
+                    obj_action = ContactActionEnum.value_of(tracked_object.action)
+                    if obj_action is not None:
+                        icon_size = int(np.clip(min(thumb_h, thumb_w) * 0.6, 80, 200))
+                        icx = int(np.clip(thumb_w - icon_size * 0.55, icon_size, width - icon_size // 2 - 5))
+                        icy = int(np.clip(icon_size * 0.5 + 130, 0, max(thumb_h - icon_size * 0.5, icon_size)))
+                        ContactDetectionNode.draw_action_icon(event_frame, obj_action, (icx, icy), size=icon_size)
             print("----------------------")
 
             for hand, object_item in result_list:
@@ -274,13 +290,18 @@ class ContactDetectionNode(ImagePreviewNode):
 
                 color = self.get_color_from_action(action)
 
+                # who: 名前があれば併記（暫定は'?'付きのまま表示）。無ければ体ID。
+                who = person.face_name if person.face_name else f'ID:{re.sub(".*_", "", person.people_id)}'
+
                 # Actionの表示
                 pixel_point = person.point_data[index].pixel_point
                 x = np.clip(int(pixel_point.x), 0, width - 1)
                 y = np.clip(int(pixel_point.y), 0, height - 1)
                 cv2.putText(color_img, f'Action : {action.value}', (x - 40, y - 10), cv2.FONT_HERSHEY_PLAIN, 1.5, color, thickness=2)
-                cv2.rectangle(event_frame, (0, height - 100), (width//4 + 40, height), (0,0,0), -1)
-                cv2.putText(event_frame, f'{action.value}', (20, height - 30), cv2.FONT_HERSHEY_SIMPLEX, 2.5, color, thickness=5)
+                # 右ウィンドウ下部: 下部全幅の黒帯 + 大きな「action : who」（矢印は物体画像の右上に別途描画）
+                cv2.rectangle(event_frame, (0, height - 130), (width, height), (0, 0, 0), -1)
+                cv2.putText(event_frame, f'{action.value} : {who}', (20, height - 40),
+                            cv2.FONT_HERSHEY_SIMPLEX, 2.2, color, thickness=5)
 
             if len(result_list) > 0:
                 cv2.putText(color_img, 'Detected', (0, 10), cv2.FONT_HERSHEY_PLAIN, 1, (0, 0, 255))
@@ -297,11 +318,13 @@ class ContactDetectionNode(ImagePreviewNode):
                 if len(self.event_frame_list) > 4:
                     del self.event_frame_list[-1]
 
+            # 各サムネイル上部に時系列キャプション（current=最新 / oldest=最古の有効枠）を焼く。
+            tiles = self._captioned_event_tiles()
             tile_img = cv2.hconcat([
                 color_img,
                 cv2.vconcat([
-                cv2.hconcat([self.event_frame_list[0], self.event_frame_list[1]]),
-                cv2.hconcat([self.event_frame_list[2], self.event_frame_list[3]])
+                cv2.hconcat([tiles[0], tiles[1]]),
+                cv2.hconcat([tiles[2], tiles[3]])
                 ])
             ])
             cv2.namedWindow('contact_detection', cv2.WINDOW_NORMAL)
@@ -313,6 +336,20 @@ class ContactDetectionNode(ImagePreviewNode):
             print(f'[{datetime.datetime.now()}] fps : {self.fps}', end='\r')
 
     @staticmethod
+    def get_person_box_color_label(person) -> Tuple[Tuple[int, int, int], str]:
+        """
+        人物の顔結合状態から (枠色BGR, ラベル文字列) を返す（people_tracking と統一）.
+
+        確定('user_xxx')→青+名前 / 暫定('user_xxx?')→赤+名前? / 未結合('')→灰+'ID : n'
+        """
+        face_name = person.face_name
+        if not face_name:
+            return (160, 160, 160), f'ID : {re.sub(".*_", "", person.people_id)}'  # 灰
+        if face_name.endswith('?'):
+            return (0, 0, 255), face_name        # 赤：暫定
+        return (255, 0, 0), face_name            # 青：確定
+
+    @staticmethod
     def get_color_from_action(action: ContactActionEnum) -> Tuple[int, int, int]:
         if action == ContactActionEnum.BRING_IN:
             return 128, 255, 255
@@ -321,6 +358,80 @@ class ContactDetectionNode(ImagePreviewNode):
         if action == ContactActionEnum.OBJ_MOVE:
             return 125, 255, 255
         return 255, 128, 255
+
+    def _captioned_event_tiles(self) -> list:
+        """
+        右ウィンドウ用の4枚に時系列キャプションを付けたコピーを返す（④）.
+
+        新しい順に latest / 2nd / 3rd / oldest を、有効(非黒)な枠にだけ大きく焼く。
+        （有効が2枚なら latest,oldest ／3枚なら latest,2nd,oldest 等、両端を latest/oldest にする）
+        未使用（黒）の枠にはキャプションを付けない。元画像は破壊しない。
+        """
+        tiles = [t.copy() for t in self.event_frame_list[:4]]
+        # 有効（黒でない）枠のインデックスを新しい順に集める
+        valid = [i for i, t in enumerate(self.event_frame_list[:4]) if t.any()]
+
+        def caption(idx, text):
+            img = tiles[idx]
+            tw, th = cv2.getTextSize(text, cv2.FONT_HERSHEY_SIMPLEX, 1.5, 3)[0]
+            # 物体ID(左上)と被らないよう、キャプションは各画像の右上に置く。
+            x0 = max(0, img.shape[1] - tw - 24)
+            cv2.rectangle(img, (x0, 0), (img.shape[1], th + 22), (0, 0, 0), -1)
+            cv2.putText(img, text, (x0 + 12, th + 10), cv2.FONT_HERSHEY_SIMPLEX, 1.5,
+                        (0, 255, 255), thickness=3)
+
+        n = len(valid)
+        ordinal = {1: '2nd', 2: '3rd'}       # 中間枠の順位表記（最大4枚なので2nd/3rdのみ）
+        for rank, idx in enumerate(valid):
+            if rank == 0:
+                label = 'latest'
+            elif rank == n - 1:
+                label = 'oldest'
+            else:
+                label = ordinal.get(rank, f'{rank + 1}th')
+            caption(idx, label)
+        return tiles
+
+    @staticmethod
+    def draw_action_icon(img: np.ndarray, action: ContactActionEnum,
+                         center: Tuple[int, int], size: int = 46) -> None:
+        """
+        イベント種別を一目で分かる太い図で描く（③）.
+
+        take_out=上向き矢印(赤) / bring_in=下向き矢印(緑) / obj_move=左右両向き矢印(橙) /
+        touch=丸+中心点(黄)。cv2 の線描画のみでフォント非依存。太さ・矢じりは size に比例。
+        """
+        cx, cy = center
+        h = size // 2
+        w = size // 3
+        th = max(4, size // 8)     # 太さ（サイズに比例。大きいほど太い）
+        tip = max(10, size // 4)   # 矢じりの長さ（サイズに比例）
+
+        def arrow(color, up: bool):
+            # 縦の軸
+            y_tail = cy + h if up else cy - h
+            y_head = cy - h if up else cy + h
+            cv2.line(img, (cx, y_tail), (cx, y_head), color, th, cv2.LINE_AA)
+            # 矢じり
+            dy = -tip if up else tip
+            cv2.line(img, (cx, y_head), (cx - w, y_head - dy), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx, y_head), (cx + w, y_head - dy), color, th, cv2.LINE_AA)
+
+        if action == ContactActionEnum.TAKE_OUT:
+            arrow((0, 0, 255), up=True)          # 上向き・赤（持ち出し）
+        elif action == ContactActionEnum.BRING_IN:
+            arrow((0, 200, 0), up=False)         # 下向き・緑（持ち込み）
+        elif action == ContactActionEnum.OBJ_MOVE:
+            color = (0, 128, 255)                # 橙（移動）：左右両向き
+            cv2.line(img, (cx - h, cy), (cx + h, cy), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx - h, cy), (cx - h + tip, cy - w), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx - h, cy), (cx - h + tip, cy + w), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx + h, cy), (cx + h - tip, cy - w), color, th, cv2.LINE_AA)
+            cv2.line(img, (cx + h, cy), (cx + h - tip, cy + w), color, th, cv2.LINE_AA)
+        else:  # TOUCH
+            color = (0, 255, 255)                # 黄（タッチ）：丸＋中心点
+            cv2.circle(img, (cx, cy), h, color, th, cv2.LINE_AA)
+            cv2.circle(img, (cx, cy), 4, color, thickness=-1)
 
 
 def main(args=None):

--- a/shigure_core/shigure_core/nodes/node_face_models.py
+++ b/shigure_core/shigure_core/nodes/node_face_models.py
@@ -93,10 +93,13 @@ class FaceCaptureNode(Node):
                 self.save_face_data(face_crop, iface_face.embedding)
 
     def save_face_data(self, face_image, feature_vector):
-        # 保存するファイル名を設定
+        # 保存するファイル名を設定。命名は '{user_id}_{num}'（= 'user_{name}_{num}'）に統一する。
+        # （自動登録(people_recognition)や shigure_api の feature_num パースと同じ規則にして
+        #   PCAプロット等の不整合を防ぐ。ディレクトリ名は 'user_{name}'）
         self.feature_count += 1
-        img_filename = os.path.join(self.save_directory, f"{self.name}{self.feature_count}.jpg")
-        npy_filename = os.path.join(self.save_directory, f"{self.name}{self.feature_count}.npy")
+        user_id = os.path.basename(self.save_directory)  # 'user_{name}'
+        img_filename = os.path.join(self.save_directory, f"{user_id}_{self.feature_count}.jpg")
+        npy_filename = os.path.join(self.save_directory, f"{user_id}_{self.feature_count}.npy")
 
         # 顔画像を保存 (JPEG)
         cv2.imwrite(img_filename, face_image)

--- a/shigure_core/shigure_core/nodes/node_people_recognition.py
+++ b/shigure_core/shigure_core/nodes/node_people_recognition.py
@@ -31,7 +31,7 @@ PROFILE_COSINE_THRESHOLD = 0.4
 NORML2_THRESHOLD = 1.128
 LP_CONFIDENCE_THRESHOLD = 0.7
 FAISS_FALLBACK_MIN_VOTE_RATIO = 0.5
-MIN_DET_SCORE = 0.8
+MIN_DET_SCORE = 0.5  # 顔検出器(det_score)の採用しきい値の既定。param min_det_score で実行中変更可
 # 新規ユーザーとして辞書登録する最低特徴数（この数を超えたら dictionary_renew で登録判定）。
 MIN_FEATURES_FOR_NEW_USER = 20
 
@@ -67,9 +67,20 @@ class PeopleRecognitionNode(ImagePreviewNode):
         self.declare_parameter('save_registration', False, save_registration_descriptor)
         self.save_registration: bool = \
             self.get_parameter('save_registration').get_parameter_value().bool_value
+
+        # 顔検出器(det_score)の採用しきい値。低いほど小さい/遠い顔も拾うが誤検出は増える
+        # （誤検出は照合(COSINE_THRESHOLD)で unknown に落ちるため誤命名リスクは低い）。
+        min_det_score_descriptor = ParameterDescriptor(
+            type=ParameterType.PARAMETER_DOUBLE,
+            description='顔検出器の信頼度(det_score)の採用しきい値。これ未満の顔は照合対象外。')
+        self.declare_parameter('min_det_score', MIN_DET_SCORE, min_det_score_descriptor)
+        self.min_det_score: float = \
+            self.get_parameter('min_det_score').get_parameter_value().double_value
+
         # 基底クラスの _on_set_parameters は上書きせず、専用コールバックを追加登録する。
         self.add_on_set_parameters_callback(self._on_set_parameters_people_recognition)
         self.get_logger().info('SaveRegistration : ' + str(self.save_registration))
+        self.get_logger().info('MinDetScore : ' + str(self.min_det_score))
 
         # QoS Settings
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
@@ -127,6 +138,9 @@ class PeopleRecognitionNode(ImagePreviewNode):
             if param.name == 'save_registration':
                 self.save_registration = param.value
                 self.get_logger().info('SaveRegistration : ' + str(self.save_registration))
+            elif param.name == 'min_det_score':
+                self.min_det_score = param.value
+                self.get_logger().info('MinDetScore : ' + str(self.min_det_score))
         return SetParametersResult(successful=True)
 
     def rebuild_pca_model_on_disk(self) -> None:
@@ -346,8 +360,8 @@ class PeopleRecognitionNode(ImagePreviewNode):
             if x < 20 or y < 20 or x + w > cap_width -20 or y + h > cap_height -20:
                 continue  # 画面外の顔を無視
 
-            # 検出信頼度が低い顔は照合・辞書蓄積の対象外
-            if iface_face.det_score < MIN_DET_SCORE:
+            # 検出信頼度が低い顔は照合・辞書蓄積の対象外（param min_det_score で調整可）
+            if iface_face.det_score < self.min_det_score:
                 continue
 
             face_info = FaceInfo()

--- a/shigure_core/shigure_core/nodes/node_people_recognition.py
+++ b/shigure_core/shigure_core/nodes/node_people_recognition.py
@@ -31,7 +31,7 @@ PROFILE_COSINE_THRESHOLD = 0.4
 NORML2_THRESHOLD = 1.128
 LP_CONFIDENCE_THRESHOLD = 0.7
 FAISS_FALLBACK_MIN_VOTE_RATIO = 0.5
-MIN_DET_SCORE = 0.5  # 顔検出器(det_score)の採用しきい値の既定。param min_det_score で実行中変更可
+MIN_DET_SCORE = 0.4  # 顔検出器(det_score)の採用しきい値の既定。param min_det_score で実行中変更可
 # 新規ユーザーとして辞書登録する最低特徴数（この数を超えたら dictionary_renew で登録判定）。
 MIN_FEATURES_FOR_NEW_USER = 20
 

--- a/shigure_core/shigure_core/nodes/node_people_recognition.py
+++ b/shigure_core/shigure_core/nodes/node_people_recognition.py
@@ -401,15 +401,17 @@ class PeopleRecognitionNode(ImagePreviewNode):
 
             x, y, w, h = iface_face.bbox
             self.all_images[self.feature_num] = image[y:y + h, x:x + w].copy()
-
-            # 描画ノード用に特徴を配信
-            feat_msg = FeatureInfo()
-            feat_msg.feature_num = int(self.feature_num)
-            feat_msg.feature = embedding.astype(np.float32).tolist()
-            self.feature_pub.publish(feat_msg)
         else:
             user_id, score = self.matching(embedding, self.profile_dictionary, PROFILE_COSINE_THRESHOLD)
             face_id = f"{user_id}@profile" if user_id != "unknown" else "unknown@profile"
+
+        # 描画/PCAプロット用に特徴を配信する（正面・非正面を問わず全ての検出顔）。
+        # unlabeled プロットのリアルタイム表示は feature_info を元にするため、
+        # 非正面(@profile)顔でも配信して現フレームの点を出せるようにする。
+        feat_msg = FeatureInfo()
+        feat_msg.feature_num = int(self.feature_num)
+        feat_msg.feature = embedding.astype(np.float32).tolist()
+        self.feature_pub.publish(feat_msg)
 
         return face_id, score, box, embedding.astype(np.float32).tolist()
             

--- a/shigure_core/shigure_core/nodes/node_people_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_people_tracking.py
@@ -43,6 +43,7 @@ class PeopleTrackingNode(ImagePreviewNode):
         shigure_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
 
         # 顔認識結果(体ID→顔ID)の累積履歴。 {people_id: {face_id: {"score", "features_num", "total_features"}}}
+        # 暫定名・確定名ともこの累積のargmaxから決める（案B: latch。get_most_likely_face_id 参照）。
         self.recognition_history = {}
 
         # 横顔プロフィール保存用の状態
@@ -273,6 +274,24 @@ class PeopleTrackingNode(ImagePreviewNode):
         display_id = most_likely_id.replace('@profile', '')
         return display_id, data['score']
 
+    def resolve_face_name(self, people_id):
+        """
+        体IDに対する face_name を決める.
+
+        累積スコアが閾値以上なら確定名（例 'user_nakamura'）を返す。
+        未確定でも現フレームの暫定Top1があれば末尾に '?' を付けた暫定名（例 'user_nakamura?'）を返す。
+        どちらも無ければ空文字を返す。
+        """
+        # 暫定・確定とも累積(recognition_history)のargmaxを使う（案B: latch）。
+        # 累積は追跡が続く限り残るため、顔が見えなくなっても・別人が一瞬映っても、
+        # 累積で勝っている人物の名前が保持され続ける（instantaneousな上書きで消えない）。
+        name, score = self.get_most_likely_face_id(people_id)
+        if name is None or name.startswith('unknown'):
+            return ''
+        if score >= self.face_name_score_threshold:
+            return name          # 確定：?なし
+        return name + '?'        # 暫定：?付き（累積argmaxなのでlatchされる）
+
     def _cleanup_recognition_history(self):
         """現在追跡していない体IDの顔認識履歴・確定名・横顔保存状態を破棄する."""
         current_ids = set(self.tracking_info.get_people_dict().keys())
@@ -408,10 +427,9 @@ class PeopleTrackingNode(ImagePreviewNode):
             _, _, _, openpose_pose_key_points = people
             shigure_pose_key_points = pose_key_points_util.convert_openpose_to_shigure(openpose_pose_key_points,
                                                                                        depth_img, people_id, k)
-            # 顔認識で対応が取れた名前(顔ID)を付与する。しきい値未満は未確定として空のまま。
-            face_name, score = self.get_most_likely_face_id(people_id)
-            if face_name is not None and score >= self.face_name_score_threshold:
-                shigure_pose_key_points.face_name = face_name
+            # 顔認識で対応が取れた名前を付与する。
+            # 確定(累積≥閾値)なら 'user_xxx'、未確定でも暫定Top1があれば 'user_xxx?'、無ければ空。
+            shigure_pose_key_points.face_name = self.resolve_face_name(people_id)
             publish_msg.pose_key_points_list.append(shigure_pose_key_points)
         self._publisher.publish(publish_msg)
 
@@ -482,16 +500,50 @@ class PeopleTrackingNode(ImagePreviewNode):
                 bounding_box.y + bounding_box.height) if bounding_box.y + bounding_box.height < height else height - 1
 
             people_id_num = int(re.sub(".*_", "", people_id))
-            color = self._colors[people_id_num % 255]
-            # 顔認識で名前が確定していれば名前を、無ければ体IDを表示する（オクルージョンによるID変化を吸収）
-            label = pose_key_points.face_name if pose_key_points.face_name else f'ID : {people_id_num}'
+            # face_name の状態で枠色とラベルを決める（ミスリード防止のため色を厳密に固定）:
+            #   確定('user_xxx')   → 青枠(255,0,0)  ＋ 名前
+            #   暫定('user_xxx?')  → 赤枠(0,0,255)  ＋ 名前?
+            #   未認識('')         → 灰枠(160,160,160) ＋ 'ID : n'（体IDの色は使わない）
+            face_name = pose_key_points.face_name
+            if not face_name:
+                color = (160, 160, 160)  # 灰：顔と未結合
+                label = f'ID : {people_id_num}'
+            elif face_name.endswith('?'):
+                color = (0, 0, 255)      # 赤(BGR)：暫定
+                label = face_name
+            else:
+                color = (255, 0, 0)      # 青(BGR)：確定
+                label = face_name
             cv2.circle(color_img, (x, y), 5, color, thickness=-1)
             cv2.rectangle(color_img, (left, top), (right, bottom), color, thickness=3)
             text_w, text_h = cv2.getTextSize(label,
-                                             cv2.FONT_HERSHEY_PLAIN, 1.5, 2)[0]
-            cv2.rectangle(color_img, (left, top), (left + text_w, top - text_h), color, -1)
-            cv2.putText(color_img, label, (left, top),
-                        cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
+                                             cv2.FONT_HERSHEY_PLAIN, 2.5, 3)[0]
+            cv2.rectangle(color_img, (left, top - text_h - 6), (left + text_w, top), color, -1)
+            cv2.putText(color_img, label, (left, top - 4),
+                        cv2.FONT_HERSHEY_PLAIN, 2.5, (255, 255, 255), thickness=3)
+
+        # ① 認識中の顔box（people_recognition の検出結果）を描画する。
+        self._draw_face_boxes(color_img)
+
+    def _draw_face_boxes(self, color_img: np.ndarray) -> None:
+        """現フレームの顔検出box(/face_recognition/results)を描画する（①）."""
+        face_data = getattr(self, 'current_face_data', None)
+        if face_data is None:
+            return
+        height, width = color_img.shape[:2]
+        for face_info in face_data.faces:
+            box = list(face_info.box)
+            if len(box) != 4:
+                continue
+            fx, fy, fw, fh = [int(v) for v in box]
+            left = max(0, fx)
+            top = max(0, fy)
+            right = min(width - 1, fx + fw)
+            bottom = min(height - 1, fy + fh)
+            # 顔ID(faiss最近傍Top1)が実名なら緑、unknownなら灰の細枠。
+            fid = face_info.id.replace('@profile', '')
+            face_color = (128, 128, 128) if fid.startswith('unknown') else (0, 200, 0)
+            cv2.rectangle(color_img, (left, top), (right, bottom), face_color, thickness=2)
 
     def _publish_tracking_debug_image(self, color_img: np.ndarray) -> None:
         """オーバーレイ画像を JPEG エンコードして /shigure/tracking_debug_image に配信する(Web表示用)."""

--- a/shigure_core/shigure_core/nodes/node_people_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_people_tracking.py
@@ -154,15 +154,20 @@ class PeopleTrackingNode(ImagePreviewNode):
         self.declare_parameter('face_name_score_threshold', 3.0,
                                ParameterDescriptor(type=ParameterType.PARAMETER_DOUBLE,
                                                    description='face_name を確定として publish する累積スコアのしきい値（コサイン類似度の累積和）。未満は未確定として空文字を publish する。'))
+        self.declare_parameter('tracking_max_age', 5,
+                               ParameterDescriptor(type=ParameterType.PARAMETER_INTEGER,
+                                                   description='人物を見失っても people_id を保持する最大フレーム数。'
+                                                               '再出現時に同じIDへ復帰させIDの振り直し（顔名累積のリセット）を抑制する。0で従来動作。'))
 
         self.threshold_distance: int = self.get_parameter('threshold_distance').get_parameter_value().integer_value
         self.threshold_person: float = self.get_parameter('threshold_person').get_parameter_value().double_value
         self.neck_index: int = self.get_parameter('neck_index').get_parameter_value().integer_value
         self.face_name_score_threshold: float = self.get_parameter('face_name_score_threshold').get_parameter_value().double_value
+        self.tracking_max_age: int = self.get_parameter('tracking_max_age').get_parameter_value().integer_value
 
         self.add_on_set_parameters_callback(self._on_set_parameters_people_tracking)
 
-        self.tracking_info = TrackingInfo()
+        self.tracking_info = TrackingInfo(max_age=self.tracking_max_age)
         self.people_tracking_logic = PeopleTrackingLogic()
 
         self._colors = []
@@ -196,6 +201,10 @@ class PeopleTrackingNode(ImagePreviewNode):
             elif param.name == 'enable_profile_insightface':
                 self.enable_profile_insightface = param.value
                 self.get_logger().info('EnableProfileInsightface : ' + str(self.enable_profile_insightface))
+            elif param.name == 'tracking_max_age':
+                self.tracking_max_age = param.value
+                self.tracking_info.set_max_age(param.value)
+                self.get_logger().info('TrackingMaxAge : ' + str(self.tracking_max_age))
         return SetParametersResult(successful=True)
 
     @staticmethod
@@ -293,8 +302,12 @@ class PeopleTrackingNode(ImagePreviewNode):
         return name + '?'        # 暫定：?付き（累積argmaxなのでlatchされる）
 
     def _cleanup_recognition_history(self):
-        """現在追跡していない体IDの顔認識履歴・確定名・横顔保存状態を破棄する."""
-        current_ids = set(self.tracking_info.get_people_dict().keys())
+        """現在追跡していない体IDの顔認識履歴・確定名・横顔保存状態を破棄する.
+
+        coasting（見失い中だが max_age 以内）の体IDは生存扱いにして履歴を残す。
+        こうしないと1フレームの取りこぼしで顔名累積が消えてしまう。
+        """
+        current_ids = self.tracking_info.get_alive_ids()
         for people_id in list(self.recognition_history.keys()):
             if people_id not in current_ids:
                 del self.recognition_history[people_id]

--- a/shigure_core/shigure_core/nodes/node_record_event.py
+++ b/shigure_core/shigure_core/nodes/node_record_event.py
@@ -141,16 +141,28 @@ class SubtractionAnalysisNode(ImagePreviewNode):
 
                 # db書き込み
                 # ------
-                EventRepository.insert_people(contacted.people_id, contacted.face_name, event_save_path, scene.event.people_bounding_box.width, scene.event.people_bounding_box.height)
+                EventRepository.insert_people(
+                    contacted.people_id,
+                    contacted.face_name,
+                    event_save_path,
+                    scene.event.people_bounding_box.width,
+                    scene.event.people_bounding_box.height,
+                    bbox_x=scene.event.people_bounding_box.x,
+                    bbox_y=scene.event.people_bounding_box.y,
+                )
                 EventRepository.insert_object(
-                    contacted.object_id, 
-                    event_save_path, 
-                    contacted.object_cube.x, 
-                    contacted.object_cube.y, 
-                    contacted.object_cube.z, 
-                    contacted.object_cube.width, 
-                    contacted.object_cube.height, 
-                    contacted.object_cube.depth, 
+                    contacted.object_id,
+                    event_save_path,
+                    contacted.object_cube.x,
+                    contacted.object_cube.y,
+                    contacted.object_cube.z,
+                    contacted.object_cube.width,
+                    contacted.object_cube.height,
+                    contacted.object_cube.depth,
+                    bbox_x=scene.event.object_bounding_box.x,
+                    bbox_y=scene.event.object_bounding_box.y,
+                    bbox_width=scene.event.object_bounding_box.width,
+                    bbox_height=scene.event.object_bounding_box.height,
                 )
 
                 frame_id = str(camera_info.header.frame_id)

--- a/shigure_core/shigure_core/nodes/people_tracking/logic.py
+++ b/shigure_core/shigure_core/nodes/people_tracking/logic.py
@@ -85,16 +85,19 @@ class PeopleTrackingLogic:
 
     @staticmethod
     def tracking(current_people_list: list, tracking_info: TrackingInfo, threshold_distance: int) -> TrackingInfo:
-        previous_people_dict = tracking_info.get_people_dict()
+        # マッチ候補は「前フレーム可視 ＋ 直近で見失った coasting」。
+        # coasting を候補に含めることで、数フレーム見失った人物が再出現しても
+        # 同じ people_id へ復帰でき、IDの振り直し（顔名累積のリセット）を抑制する。
+        match_pool = tracking_info.get_match_pool()
         current_people_dict = {}
-        if len(previous_people_dict) == 0:
+        if len(match_pool) == 0:
             for people in current_people_list:
                 current_people_dict[tracking_info.new_people_id()] = people
-            tracking_info.update_people_dict(current_people_dict)
+            tracking_info.commit(current_people_dict)
             return tracking_info
 
         linked_list = []
-        for people_id, previous_people in previous_people_dict.items():
+        for people_id, previous_people in match_pool.items():
             previous_x, previous_y, previous_z, _ = previous_people
             for current_people in current_people_list:
                 current_x, current_y, current_z, key_point = current_people
@@ -111,15 +114,18 @@ class PeopleTrackingLogic:
                     linked_list.append((people_id, current_people, current_diff_sum))
 
         linked_list = sorted(linked_list, key=itemgetter(2))
+        remaining = list(current_people_list)
         for people_id, people, _ in linked_list:
-            if people_id not in current_people_dict.keys() and people in current_people_list:
+            if people_id not in current_people_dict.keys() and people in remaining:
                 current_people_dict[people_id] = people
-                current_people_list.remove(people)
+                remaining.remove(people)
 
         # 余った人物は新規登録
-        for people in current_people_list:
+        for people in remaining:
             current_people_dict[tracking_info.new_people_id()] = people
 
-        tracking_info.update_people_dict(current_people_dict)
+        # commit が可視(current_people_dict)を反映し、未マッチの候補を age++ して
+        # max_age 以内なら coasting に残す（超えたら破棄＝完全ロスト）。
+        tracking_info.commit(current_people_dict)
 
         return tracking_info

--- a/shigure_core/shigure_core/nodes/people_tracking/tracking_info.py
+++ b/shigure_core/shigure_core/nodes/people_tracking/tracking_info.py
@@ -2,13 +2,28 @@ import datetime
 
 
 class TrackingInfo:
-    """人物追跡のためのデータクラス."""
+    """人物追跡のためのデータクラス.
 
-    def __init__(self):
+    max_age フレームまでは「見失った人物」を coasting として保持し、再出現時に
+    同じ people_id へ再マッチできるようにする（1フレームの取りこぼしで別人扱い＝
+    IDが振り直され顔名の累積スコアがリセットされるのを抑制する）。
+
+    - 可視人物 (get_people_dict): 現フレームで検出された人物。publish/描画の対象。
+    - coasting: 直近で見失った人物。マッチ候補としてのみ使う（幽霊BBOXは出さない）。
+    """
+
+    def __init__(self, max_age: int = 0):
         self._people_num = 0
         self._id_prefix = f'{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}_'
 
-        self._people_dict = {}
+        self._people_dict = {}  # 現フレームで可視の人物 {id: (x, y, z, key_points)}
+        self._coasting = {}     # 直近で見失った人物 {id: (x, y, z, key_points)}
+        self._age = {}          # {id: 連続で見失ったフレーム数}
+        self._max_age = max(0, int(max_age))
+
+    def set_max_age(self, max_age: int) -> None:
+        """coasting で保持する最大フレーム数を更新する（0で従来動作＝保持しない）。"""
+        self._max_age = max(0, int(max_age))
 
     def new_people_id(self) -> str:
         """新しい人物idを取得します."""
@@ -20,9 +35,41 @@ class TrackingInfo:
         return f'{self._id_prefix}{people_num}'
 
     def get_people_dict(self) -> dict:
-        """人物idをキーとする一覧を取得します."""
+        """現フレームで可視の人物一覧（publish/描画の対象）を取得します."""
         return self._people_dict
 
+    def get_match_pool(self) -> dict:
+        """フレーム間マッチの候補（可視＋coasting）を取得します."""
+        pool = dict(self._people_dict)
+        pool.update(self._coasting)
+        return pool
+
+    def get_alive_ids(self) -> set:
+        """履歴を残すべき生存ID（可視＋coasting）を取得します."""
+        return set(self._people_dict.keys()) | set(self._coasting.keys())
+
+    def commit(self, visible: dict) -> None:
+        """追跡結果を反映する.
+
+        :param visible: 現フレームで可視の人物 {id: (x, y, z, key_points)}。
+            既存IDに再マッチした人物は元のIDを、新規人物は新IDをキーに持つ。
+        """
+        prev_pool = self.get_match_pool()
+        new_coasting = {}
+        new_age = {}
+        for people_id, people in prev_pool.items():
+            if people_id in visible:
+                continue  # 今フレームで可視化 → coasting から外す（age リセット）
+            age = self._age.get(people_id, 0) + 1
+            if age <= self._max_age:
+                new_coasting[people_id] = people  # 最後に見えた位置で保持
+                new_age[people_id] = age
+            # age > max_age は破棄（=完全にロストしたとみなす）
+
+        self._people_dict = visible
+        self._coasting = new_coasting
+        self._age = new_age
+
     def update_people_dict(self, people_dict: dict) -> None:
-        """人物一覧を更新します."""
-        self._people_dict = people_dict
+        """人物一覧を更新します（後方互換; coasting を使わず可視のみ置き換える）."""
+        self.commit(people_dict)


### PR DESCRIPTION
顔認識の結果＋累積スコアに応じた描画方法，下流ノードに流すデータの変更
・BBOX 3段階の色分けを統一
　灰色 … 顔と骨格が未バインド（未認識）
　赤 + 「?」 … 暫定（累積スコアが閾値未満のTop1候補）
　青 + 名前 … 確定（累積スコア ≥ face_name_score_threshold）
・暫定・確定とも累積スコアの argmax で決定。
・顔が見えなくなっても同一人物の名前を継続表示
・文字を大きく（視認性改善）

イベント表示多情報化
・イベント発生時点画像にアイコンを描画
　take_out = ↑赤
　bring_in = ↓緑
　obj_move = ↔橙 
・持ち出し持ち込みのタイムライン明確描画(latest,2nd,3rd,oldest)
・誰が持ち込んだ/持ち出したかをイベント情報に付与
　DBにも保存可能

顔認識チューニング
・検出信頼度しきい値変更(緩和，0.8 → 0.5 → 0.4)
　ros2 paramでも変更可能
・新規ユーザー自動登録の最小特徴数 MIN_FEATURES_FOR_NEW_USER = 20

PCAプロットバグ修正
・顔特徴量ファイル参照名不一致修正

骨格トラッキング安定化
・各骨格にageを付与
　消えたときにageを毎フレーム加算，age<maxなら似た位置にいる骨格に同一ID割当