### PR TITLE
refactor(object_tracking): 責務分離（Visualizer / Collider 抽出）

### DIFF
--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -1,6 +1,3 @@
-import random
-import re
-
 import cv2
 import message_filters
 import numpy as np
@@ -12,6 +9,7 @@ from shigure_core_msgs.msg import DetectedObjectList, TrackedObjectList, Tracked
 from shigure_core.nodes.node_image_preview import ImagePreviewNode
 from shigure_core.nodes.object_tracking.logic import ObjectTrackingLogic
 from shigure_core.nodes.object_tracking.tracking_info import TrackingInfo
+from shigure_core.nodes.object_tracking.visualizer import ObjectTrackingVisualizer
 from shigure_core.util import compressed_depth_util
 
 
@@ -64,10 +62,6 @@ class ObjectTrackingNode(ImagePreviewNode):
             self.time_synchronizer.registerCallback(self.callback_debug)
 
         self._tracking_info = TrackingInfo()
-
-        self._colors = []
-        for i in range(255):
-            self._colors.append(tuple([random.randint(128, 192) for _ in range(3)]))
 
     def _compute_depth_range(self, depth_img: np.ndarray, stay_object, left: int, top: int,
                              right: int, bottom: int):
@@ -176,30 +170,8 @@ class ObjectTrackingNode(ImagePreviewNode):
             return
 
         color_img: np.ndarray = self.bridge.compressed_imgmsg_to_cv2(color_src)
-
-        height, width = color_img.shape[:2]
-        for object_id, item in self._tracking_info.object_dict.items():
-            stay_object, bounding_box = item
-
-            bounding_box = stay_object.bounding_box
-            left = min(int(bounding_box.x), width - 1)
-            top = min(int(bounding_box.y), height - 1)
-            right = min(int(bounding_box.x + bounding_box.width), width - 1)
-            bottom = min(int(bounding_box.y + bounding_box.height), height - 1)
-
-            object_id_num = int(re.sub(".*_", "", object_id))
-            color = self._colors[object_id_num % 255]
-            cv2.rectangle(color_img, (left, top), (right, bottom), color, thickness=3)
-            text_w, text_h = cv2.getTextSize(f'ID : {object_id_num}',
-                                             cv2.FONT_HERSHEY_PLAIN, 1.5, 2)[0]
-            cv2.rectangle(color_img, (left, top), (left + text_w, top - text_h), color, -1)
-            cv2.putText(color_img, f'ID : {object_id_num}({stay_object.action})', (left, top),
-                        cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
-
-        self.print_fps(color_img)
-        cv2.namedWindow('object_tracking', cv2.WINDOW_NORMAL)
-        cv2.imshow('object_tracking', color_img)
-        cv2.waitKey(1)
+        ObjectTrackingVisualizer.draw(color_img, self._tracking_info.object_dict,
+                                      self.frame_count, self.fps)
 
 
 def main(args=None):

--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -63,8 +63,6 @@ class ObjectTrackingNode(ImagePreviewNode):
                 [depth_subscriber, object_detection_subscriber, depth_camera_info_subscriber, color_subscriber], 400000)
             self.time_synchronizer.registerCallback(self.callback_debug)
 
-        self.people_tracking_logic = ObjectTrackingLogic()
-
         self._tracking_info = TrackingInfo()
 
         self._colors = []

--- a/shigure_core/shigure_core/nodes/node_object_tracking.py
+++ b/shigure_core/shigure_core/nodes/node_object_tracking.py
@@ -4,9 +4,10 @@ import numpy as np
 import rclpy
 from rclpy.qos import QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CompressedImage, CameraInfo
-from shigure_core_msgs.msg import DetectedObjectList, TrackedObjectList, TrackedObject, Cube
+from shigure_core_msgs.msg import DetectedObjectList, TrackedObjectList, TrackedObject
 
 from shigure_core.nodes.node_image_preview import ImagePreviewNode
+from shigure_core.nodes.object_tracking.collider import build_collider, compute_depth_range
 from shigure_core.nodes.object_tracking.logic import ObjectTrackingLogic
 from shigure_core.nodes.object_tracking.tracking_info import TrackingInfo
 from shigure_core.nodes.object_tracking.visualizer import ObjectTrackingVisualizer
@@ -63,45 +64,19 @@ class ObjectTrackingNode(ImagePreviewNode):
 
         self._tracking_info = TrackingInfo()
 
-    def _compute_depth_range(self, depth_img: np.ndarray, stay_object, left: int, top: int,
-                             right: int, bottom: int):
-        """3次元BBOXの奥行きに用いる深度範囲を求めます.
+    def _decode_mask_roi(self, mask_msg, roi_shape):
+        """物体マスク(CompressedImage)を復号し depth_roi と同形に切り出す（ROS境界）.
 
-        物体領域(セグメンテーションマスク)の縁から5pxより更に内部の深度値のうち,
-        分布の5%点を最小値, 95%点を最大値として返します. マスクが取得できない,
-        または内部に有効な深度が無い場合は bbox 内の深度最小/最大にフォールバックします.
+        マスクは bbox 左上を原点とするため、depth_roi の大きさに合わせて左上を切り出す。
+        復号失敗・2次元でない場合は None を返す（呼び出し側で bbox 深度にフォールバック）。
         """
-        depth_roi = depth_img[top:bottom, left:right]
-
-        mask_roi = None
         try:
-            mask = self.bridge.compressed_imgmsg_to_cv2(stay_object.mask)
-            if mask is not None and mask.ndim == 2:
-                # マスクは bbox 左上を原点とする. depth_roi の大きさに合わせて切り出す
-                mask_roi = mask[0:depth_roi.shape[0], 0:depth_roi.shape[1]]
+            mask = self.bridge.compressed_imgmsg_to_cv2(mask_msg)
         except Exception:
-            mask_roi = None
-
-        valid = None
-        if mask_roi is not None and mask_roi.shape == depth_roi.shape and mask_roi.any():
-            binary = (mask_roi > 0).astype(np.uint8)
-            # 縁から5pxより内部のみを残す (11x11カーネルで縁を5px収縮)
-            kernel = np.ones((11, 11), np.uint8)
-            interior_mask = cv2.erode(binary, kernel)
-            interior = (interior_mask > 0) & (depth_roi != 0.0)
-            if np.count_nonzero(interior) > 0:
-                valid = depth_roi[interior]
-
-        if valid is None or valid.size == 0:
-            # フォールバック: 従来通り bbox 内の有効深度の最小/最大を用いる
-            masked = np.ma.masked_equal(depth_roi, 0.0, copy=False)
-            if masked.count() == 0:
-                return 0.0, 0.0
-            return float(masked.min()), float(masked.max())
-
-        depth_min = float(np.percentile(valid, 5))
-        depth_max = float(np.percentile(valid, 95))
-        return depth_min, depth_max
+            return None
+        if mask is None or mask.ndim != 2:
+            return None
+        return mask[0:roi_shape[0], 0:roi_shape[1]]
 
     def callback(self, depth_src: CompressedImage, detected_object_list: DetectedObjectList,
                  camera_info: CameraInfo):
@@ -139,21 +114,10 @@ class ObjectTrackingNode(ImagePreviewNode):
             right = min(int(bounding_box.x + bounding_box.width), width - 1)
             bottom = min(int(bounding_box.y + bounding_box.height), height - 1)
 
-            depth_min, depth_max = self._compute_depth_range(depth_img, stay_object, left, top, right, bottom)
-
-            s1 = np.asarray([[bounding_box.x, bounding_box.y, 1]]).T
-            s2 = np.asarray([[bounding_box.x + bounding_box.width,
-                              bounding_box.y + bounding_box.height, 1]]).T
-
-            m1 = (depth_min * np.matmul(k_inv, s1)).T
-            m2 = (depth_min * np.matmul(k_inv, s2)).T
-
-            collider = Cube()
-            collider.x, collider.y = float(m1[0, 0]), float(m1[0, 1])
-            collider.width, collider.height = float(m2[0, 0] - m1[0, 0]), float(m2[0, 1] - m1[0, 1])
-            collider.z = float(depth_min)
-            collider.depth = float(depth_max - depth_min)
-            tracked_object.collider = collider
+            depth_roi = depth_img[top:bottom, left:right]
+            mask_roi = self._decode_mask_roi(stay_object.mask, depth_roi.shape)
+            depth_min, depth_max = compute_depth_range(depth_roi, mask_roi)
+            tracked_object.collider = build_collider(bounding_box, depth_min, depth_max, k_inv)
 
             publish_msg.tracked_object_list.append(tracked_object)
             

--- a/shigure_core/shigure_core/nodes/object_tracking/collider.py
+++ b/shigure_core/shigure_core/nodes/object_tracking/collider.py
@@ -1,0 +1,73 @@
+"""object_tracking の3Dコライダー生成（深度レンジ算出＋透視逆投影）.
+
+追跡そのもの（2D）とは独立した「2D→3D復元」の責務をここに集約する。
+ROS非依存の純関数群とし、マスクの復号(cv_bridge)などROS境界はノード側の責務とする
+（ここには decode 済みの numpy 配列を渡す）。
+
+将来的に透視逆投影 pixel→3D は util へ昇格し people_tracking 系と共有する想定。
+"""
+from typing import Optional, Tuple
+
+import cv2
+import numpy as np
+from shigure_core_msgs.msg import Cube
+
+
+def compute_depth_range(depth_roi: np.ndarray, mask_roi: Optional[np.ndarray]) -> Tuple[float, float]:
+    """物体領域の深度レンジ (min, max) を求める.
+
+    セグメンテーションマスク内部（縁から5px内側に収縮）の有効深度の 5%/95% 点を返す。
+    マスクが無い / 内部に有効深度が無い場合は bbox 内の有効深度の min/max にフォールバックし、
+    それも無ければ (0.0, 0.0) を返す。
+
+    :param depth_roi: bbox 内に切り出した深度画像 (float32)
+    :param mask_roi: depth_roi と同形の物体マスク（None 可）
+    :return: (depth_min, depth_max)
+    """
+    valid = None
+    if mask_roi is not None and mask_roi.shape == depth_roi.shape and mask_roi.any():
+        binary = (mask_roi > 0).astype(np.uint8)
+        # 縁から5pxより内部のみを残す (11x11カーネルで縁を5px収縮)
+        kernel = np.ones((11, 11), np.uint8)
+        interior_mask = cv2.erode(binary, kernel)
+        interior = (interior_mask > 0) & (depth_roi != 0.0)
+        if np.count_nonzero(interior) > 0:
+            valid = depth_roi[interior]
+
+    if valid is None or valid.size == 0:
+        # フォールバック: bbox 内の有効深度の最小/最大を用いる
+        masked = np.ma.masked_equal(depth_roi, 0.0, copy=False)
+        if masked.count() == 0:
+            return 0.0, 0.0
+        return float(masked.min()), float(masked.max())
+
+    depth_min = float(np.percentile(valid, 5))
+    depth_max = float(np.percentile(valid, 95))
+    return depth_min, depth_max
+
+
+def build_collider(bounding_box, depth_min: float, depth_max: float, k_inv: np.ndarray) -> Cube:
+    """2D bbox と深度レンジから3Dコライダー(Cube)を作る.
+
+    bbox の左上・右下を近面深度 depth_min で透視逆投影して x/y/幅/高さを求め、
+    z=depth_min・depth=depth_max-depth_min を厚みとする（角基準＋寸法表現）。
+
+    :param bounding_box: x/y/width/height を持つ2D bbox
+    :param depth_min: 近面深度
+    :param depth_max: 遠面深度
+    :param k_inv: カメラ内部行列 K の逆行列（呼び出し側で1回だけ計算して渡す）
+    :return: Cube collider
+    """
+    s1 = np.asarray([[bounding_box.x, bounding_box.y, 1]]).T
+    s2 = np.asarray([[bounding_box.x + bounding_box.width,
+                      bounding_box.y + bounding_box.height, 1]]).T
+
+    m1 = (depth_min * np.matmul(k_inv, s1)).T
+    m2 = (depth_min * np.matmul(k_inv, s2)).T
+
+    collider = Cube()
+    collider.x, collider.y = float(m1[0, 0]), float(m1[0, 1])
+    collider.width, collider.height = float(m2[0, 0] - m1[0, 0]), float(m2[0, 1] - m1[0, 1])
+    collider.z = float(depth_min)
+    collider.depth = float(depth_max - depth_min)
+    return collider

--- a/shigure_core/shigure_core/nodes/object_tracking/visualizer.py
+++ b/shigure_core/shigure_core/nodes/object_tracking/visualizer.py
@@ -1,0 +1,49 @@
+import random
+import re
+from typing import Dict
+
+import cv2
+import numpy as np
+
+# 物体IDごとの表示色（起動時に一度だけ生成）。IDの連番を255で割った余りで引く。
+_COLORS = [tuple(random.randint(128, 192) for _ in range(3)) for _ in range(255)]
+
+
+class ObjectTrackingVisualizer:
+    """object_tracking のデバッグ描画（追跡中の物体bboxとIDラベル）を担う."""
+
+    @staticmethod
+    def draw(color_img: np.ndarray, object_dict: Dict, frame_count: int, fps: float) -> None:
+        """追跡中の物体をbbox＋IDラベルで描画し、object_tracking ウィンドウに表示する."""
+        height, width = color_img.shape[:2]
+
+        for object_id, item in object_dict.items():
+            stay_object, _ = item
+            bounding_box = stay_object.bounding_box
+            left = min(int(bounding_box.x), width - 1)
+            top = min(int(bounding_box.y), height - 1)
+            right = min(int(bounding_box.x + bounding_box.width), width - 1)
+            bottom = min(int(bounding_box.y + bounding_box.height), height - 1)
+
+            object_id_num = int(re.sub('.*_', '', object_id))
+            color = _COLORS[object_id_num % 255]
+            cv2.rectangle(color_img, (left, top), (right, bottom), color, thickness=3)
+            text_w, text_h = cv2.getTextSize(f'ID : {object_id_num}',
+                                             cv2.FONT_HERSHEY_PLAIN, 1.5, 2)[0]
+            cv2.rectangle(color_img, (left, top), (left + text_w, top - text_h), color, -1)
+            cv2.putText(color_img, f'ID : {object_id_num}({stay_object.action})', (left, top),
+                        cv2.FONT_HERSHEY_PLAIN, 1.5, (255, 255, 255), thickness=2)
+
+        ObjectTrackingVisualizer._draw_fps(color_img, frame_count, fps)
+
+        cv2.namedWindow('object_tracking', cv2.WINDOW_NORMAL)
+        cv2.imshow('object_tracking', color_img)
+        cv2.waitKey(1)
+
+    @staticmethod
+    def _draw_fps(img: np.ndarray, frame_count: int, fps: float) -> None:
+        """フレーム数とFPSを左上に印字する（ImagePreviewNode.print_fps と同じ体裁）."""
+        cv2.putText(img, 'frame = ' + str(frame_count), (0, 20),
+                    cv2.FONT_HERSHEY_PLAIN, 1.5, (0, 255, 0))
+        cv2.putText(img, 'FPS: {:.2f}'.format(fps), (0, 40),
+                    cv2.FONT_HERSHEY_PLAIN, 1.5, (0, 255, 0))


### PR DESCRIPTION
## 概要

object_tracking ノードの責務分離リファクタリング。Node層に混在していた「デバッグ描画」と「3Dコライダー生成」を専用モジュールへ切り出し、yolox_object_detection と同じ Node / Logic / Visualizer 構成に揃える。**挙動は不変**（等価テスト＋実カメラ稼働で確認済み）。

## 変更（3コミット）

### 1. 未使用の誤名インスタンス削除
`self.people_tracking_logic = ObjectTrackingLogic()` を削除。object_tracking なのに `people_tracking` という誤名で、実処理は `ObjectTrackingLogic.execute()` の静的呼び出し。このインスタンスは一度も参照されないデッドコードだった。

### 2. デバッグ描画を `ObjectTrackingVisualizer` へ分離
`callback_debug` にインライン展開されていた cv2 描画を新規 `object_tracking/visualizer.py` へ集約（YoloxVisualizer と同じ流儀）。追跡物体のbbox＋IDラベル描画・色パレット・FPS印字・ウィンドウ表示をまとめ、Node 側は decode + `Visualizer.draw()` 呼び出しのみに。未使用の `import random / re` と `self._colors` も除去。

### 3. 3Dコライダー生成を `object_tracking/collider.py` へ抽出
追跡(2D)とは独立した「2D→3D復元」責務を Node から切り出す。object_tracking の追跡ロジック自体は3Dを使わず、collider は下流(contact_detection)向けの出力成果物である点を構造上も明確化。
- `compute_depth_range(depth_roi, mask_roi)`: マスク内部(erode)の深度5/95%点、無効時は bbox 深度 min/max へフォールバック
- `build_collider(bbox, depth_min, depth_max, k_inv)`: 透視逆投影で Cube 生成
- マスク復号(cv_bridge)=ROS境界のみ `_decode_mask_roi` として Node に残す

## 検証

| 観点 | 方法 | 結果 |
| :-- | :-- | :-- |
| ビルド/パッケージング | `docker compose build`（内部で `colcon build --symlink-install`） | ✅ shigure_core 含む6パッケージ成功 |
| ランタイム import | ビルド済みイメージで `node_object_tracking` / `collider` / `visualizer` を実 import | ✅ IMPORT OK |
| 描画の挙動不変 | 抽出前後の出力画像を突き合わせ | ✅ ピクセル完全一致（複数ID・action・端クランプを網羅） |
| 3D生成の挙動不変 | `compute_depth_range` の percentile経路/各fallback、`build_collider` の数値 | ✅ 6シナリオ一致 |
| 実カメラ E2E | `docker compose up`（RealSense/OpenPose/YOLOX込み）で稼働実測 | ✅ `/shigure/object_tracking` を約10Hzで配信・3Dコライダー値が妥当・エラーなし |

## 今後

透視逆投影 pixel→3D は people_tracking/logic・pose_key_points_util にも重複（かつ深度サンプリング戦略が不整合＝潜在バグ）。将来 `util/projection.py` へ横断集約する想定だが、影響が広いため**本PRは object_tracking 内に限定**。